### PR TITLE
Add prompt-chain task sequencing system

### DIFF
--- a/JULES.md
+++ b/JULES.md
@@ -8,6 +8,18 @@ Jules works **one approved GitHub issue at a time**.
 
 Do not run the full roadmap unattended. Do not start future issues early. Do not bundle unrelated roadmap groups into one PR.
 
+## Prompt-Chain Control Layer
+
+The `prompt-chains/` folder provides higher-level roadmap prompts, phase groupings, review checklists, and queue-update protocols.
+
+These files are for planning and orchestration only. They do **not** override `NEXT_TASK.md`.
+
+When there is any conflict:
+
+1. Follow `NEXT_TASK.md` for the current approved Jules task.
+2. Follow the linked GitHub issue for exact scope.
+3. Use `prompt-chains/` only as supporting guidance.
+
 ## Required Workflow
 
 For each task:
@@ -109,6 +121,7 @@ roadmap/
 examples/
 docs/
 .github/
+prompt-chains/
 ```
 
 Do not create competing folder names unless the issue explicitly requires it.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ To preview it locally, run `python3 -m http.server 8000` from the root directory
 
 To deploy it to Vercel, read the [Deployment Instructions](DEPLOYMENT.md) for a zero-config setup.
 
+## Prompt-chain command layer
+
+The [`prompt-chains/`](prompt-chains/) folder contains the repo's execution control layer for grouped planning, issue sequencing, Jules prompts, ChatGPT prompts, PR review checklists, and `NEXT_TASK.md` update rules.
+
+Use it when a build thread needs to continue across multiple issues without losing the one-issue-at-a-time PR discipline.
+
 ## Current contents
 
 ```text
@@ -37,6 +43,9 @@ ai-agent-library/
 
   docs/
     Foundation documentation, repo purpose, conventions, and standards
+
+  prompt-chains/
+    Master roadmap prompt, grouped issue phases, execution prompts, review checklist, and queue protocol
 
   templates/
     agent-build-checklist.md

--- a/prompt-chains/README.md
+++ b/prompt-chains/README.md
@@ -1,0 +1,57 @@
+# Prompt Chains
+
+This folder is the command layer for sequencing the AI Agent Library buildout across ChatGPT, Jules, Codex, and future agents.
+
+It does **not** replace `NEXT_TASK.md` or the one-issue-at-a-time Jules workflow. It adds a higher-level roadmap so grouped work can be planned, drafted, reviewed, and executed without losing PR discipline.
+
+## Purpose
+
+Use these prompt chains to:
+
+- Group Issues #5–#16 into practical execution phases.
+- Generate copy/paste prompts for Jules, ChatGPT, Codex, or other agents.
+- Keep each implementation PR narrow and reviewable.
+- Avoid scope creep across unrelated folders.
+- Preserve `NEXT_TASK.md` as the single approved Jules task queue.
+- Continue planning while a slower agent works an isolated PR.
+
+## Core rule
+
+Grouped prompt chains are for planning and sequencing. Implementation still happens through reviewed PRs.
+
+Do not batch unrelated issue implementations into one PR just because they appear in the same phase.
+
+## Files
+
+```text
+prompt-chains/
+  README.md
+  master-roadmap-prompt.md
+  grouped-task-sequence.md
+  jules-execution-prompts.md
+  chatgpt-execution-prompts.md
+  review-and-merge-checklist.md
+  next-task-update-protocol.md
+```
+
+## Recommended use
+
+1. Read `grouped-task-sequence.md` to understand phases.
+2. Use `master-roadmap-prompt.md` to continue orchestration in ChatGPT.
+3. Use `jules-execution-prompts.md` only after `NEXT_TASK.md` approves the exact issue.
+4. Use `chatgpt-execution-prompts.md` to plan or draft scoped work while another agent is busy.
+5. Use `review-and-merge-checklist.md` before approving any PR.
+6. Use `next-task-update-protocol.md` after merge to advance the queue.
+
+## Safety boundary
+
+These prompts should never ask an agent to include:
+
+- API keys
+- Secrets
+- Private client data
+- Backend-provider bypass paths
+- Unapproved lender/provider claims
+- Unreviewed production automation actions
+
+When in doubt, write the plan and stop.

--- a/prompt-chains/chatgpt-execution-prompts.md
+++ b/prompt-chains/chatgpt-execution-prompts.md
@@ -1,0 +1,130 @@
+# ChatGPT Execution Prompts
+
+Use these prompts when ChatGPT is planning, drafting, reviewing, or creating scoped PRs while Jules is slow or blocked.
+
+ChatGPT may plan across a phase, but implementation should remain PR-scoped.
+
+---
+
+## Universal ChatGPT Repo Execution Prompt
+
+```text
+This thread manages execution for JFeimster/ai-agent-library.
+
+Use GitHub connector as needed.
+
+Before making repo changes:
+1. Check current open PRs.
+2. Check the relevant issue.
+3. Confirm the intended branch and file scope.
+4. Avoid touching unrelated files.
+
+Task:
+[INSERT TASK]
+
+Rules:
+- Keep work scoped to the requested issue or planning artifact.
+- Do not combine unrelated tasks.
+- Use reviewed PRs for implementation.
+- Do not include secrets, API keys, private client data, or backend-provider bypass paths.
+- If source data is missing, say so and mark values Unknown rather than inventing.
+
+Deliver:
+- Branch name
+- Files changed
+- Commit message
+- PR title/body
+- Review checklist
+```
+
+---
+
+## Phase A Planning Prompt — Core Knowledge Bases
+
+```text
+Plan Phase A for JFeimster/ai-agent-library without implementing files yet.
+
+Phase A issues:
+- #5 Add Moonshine Capital funding knowledge base
+- #6 Add partner enablement knowledge base
+- #7 Add engineering-as-marketing knowledge base
+- #8 Add CRM, automation, content ops, and local referral knowledge bases
+
+For each issue, produce:
+- Recommended branch name
+- Exact file list
+- Source assumptions
+- Crosslinks to existing agents/platforms
+- Guardrails
+- PR stop condition
+
+Do not create files yet unless explicitly approved.
+```
+
+---
+
+## Issue Implementation Draft Prompt
+
+```text
+Prepare an implementation plan for Issue #[NUMBER] in JFeimster/ai-agent-library.
+
+Use the issue body as source of truth.
+
+Output:
+1. Scope summary
+2. Branch name
+3. Exact files to create/update
+4. Files not to touch
+5. Content structure for each file
+6. Risk notes
+7. Review checklist
+8. Jules prompt if this should be delegated
+9. ChatGPT execution plan if this should be done here
+
+Do not implement until approved.
+```
+
+---
+
+## PR Review Prompt
+
+```text
+Review PR #[NUMBER] in JFeimster/ai-agent-library.
+
+Check:
+- Does it match the linked issue?
+- Are changed files in scope?
+- Did it start future issues?
+- Are there secrets, private data, or unsafe backend-provider details?
+- Are generated indexes consistent with source files?
+- Are README links accurate?
+- Are conflicts resolved?
+
+Return:
+- Approve or request changes
+- Blocking issues
+- Non-blocking notes
+- Exact comment to leave on the PR if revisions are needed
+```
+
+---
+
+## Queue Update Prompt
+
+```text
+A PR has merged in JFeimster/ai-agent-library.
+
+Update NEXT_TASK.md to the next approved issue.
+
+Inputs:
+- Merged PR number: [PR]
+- Completed issue: #[NUMBER]
+- Next issue: #[NUMBER]
+- Next branch: [BRANCH]
+
+Rules:
+- Update only NEXT_TASK.md unless explicitly asked otherwise.
+- Remove the next issue from Upcoming Tasks.
+- Preserve the reusable Jules prompt.
+- Commit directly to main.
+```

--- a/prompt-chains/grouped-task-sequence.md
+++ b/prompt-chains/grouped-task-sequence.md
@@ -1,0 +1,155 @@
+# Grouped Task Sequence
+
+This file groups the remaining AI Agent Library issues into execution phases.
+
+The phases are for planning and sequencing. They are **not** permission to merge unrelated issue work into one PR.
+
+## Active constraint
+
+`NEXT_TASK.md` remains the single approved Jules task queue.
+
+A phase can be planned as a group, but implementation should remain issue-scoped unless the user explicitly approves a grouped PR.
+
+---
+
+## Phase A — Core Knowledge Bases
+
+### Issues
+
+- #5 Add Moonshine Capital funding knowledge base
+- #6 Add partner enablement knowledge base
+- #7 Add engineering-as-marketing knowledge base
+- #8 Add CRM, automation, content ops, and local referral knowledge bases
+
+### Goal
+
+Create the knowledge foundation that future agents, platform packs, examples, and schemas can reference.
+
+### Expected folders
+
+```text
+knowledge-base/
+  funding/
+  partner-enablement/
+  engineering-as-marketing/
+  crm/
+  automation/
+  content-ops/
+  local-referrals/
+```
+
+### Execution rule
+
+Run each issue as its own PR unless a grouped documentation-only PR is explicitly approved.
+
+### Recommended order
+
+1. #5 Funding knowledge base
+2. #6 Partner enablement knowledge base
+3. #7 Engineering-as-marketing knowledge base
+4. #8 CRM, automation, content ops, and local referral knowledge bases
+
+---
+
+## Phase B — Data + Platform Expansion
+
+### Issues
+
+- #9 Add schema definitions
+- #10 Expand platform implementation packs
+- #11 Expand reusable templates
+
+### Goal
+
+Turn the documentation library into a structured, reusable, cross-platform system.
+
+### Expected folders
+
+```text
+schemas/
+platforms/
+templates/
+```
+
+### Execution rule
+
+Schemas should land before platform/template expansion where possible, because the later files should reference canonical data structures.
+
+### Recommended order
+
+1. #9 Schema definitions
+2. #10 Platform implementation packs
+3. #11 Reusable templates
+
+---
+
+## Phase C — Portfolio + Roadmap Layer
+
+### Issues
+
+- #12 Add portfolio inventories
+- #13 Add roadmap folder
+- #14 Add agent usage examples
+
+### Goal
+
+Make the library usable as a public-facing portfolio, execution roadmap, and example library.
+
+### Expected folders
+
+```text
+portfolio/
+roadmap/
+examples/
+```
+
+### Execution rule
+
+Portfolio and examples should reference the knowledge bases, schemas, and platform packs created in earlier phases.
+
+### Recommended order
+
+1. #12 Portfolio inventories
+2. #13 Roadmap folder
+3. #14 Agent usage examples
+
+---
+
+## Phase D — Repo Hygiene + Final Crosslinks
+
+### Issues
+
+- #15 Add GitHub project hygiene files
+- #16 Add final indexes and crosslinks
+
+### Goal
+
+Make the repo easier to maintain, review, navigate, and hand off to agents or human collaborators.
+
+### Expected folders/files
+
+```text
+.github/
+README.md
+agents.md
+agent-index.json
+folder README files
+crosslinks
+```
+
+### Execution rule
+
+Run hygiene after the main structure exists so templates and indexes reference real files instead of wishful architecture cosplay.
+
+### Recommended order
+
+1. #15 GitHub project hygiene files
+2. #16 Final indexes and crosslinks
+
+---
+
+## Parking lot
+
+Issue #20 adds this prompt-chain system. It should land before Phase A if the user wants faster multi-agent orchestration.
+
+Issue #4 may still be in progress through Jules. Do not block the Phase A planning process on Issue #4 unless #5 explicitly depends on the final ChatGPT GPT inventory output.

--- a/prompt-chains/jules-execution-prompts.md
+++ b/prompt-chains/jules-execution-prompts.md
@@ -1,0 +1,148 @@
+# Jules Execution Prompts
+
+Use these prompts only when `NEXT_TASK.md` approves the exact issue.
+
+Jules should not work future issues just because they appear in the same phase.
+
+---
+
+## Universal Jules Prompt
+
+```text
+Use repository JFeimster/ai-agent-library.
+
+Read JULES.md and NEXT_TASK.md first.
+
+Work only the Current Approved Task listed in NEXT_TASK.md.
+
+Confirm the issue number, issue title, and branch name before editing files.
+
+Follow the linked GitHub issue exactly.
+
+Create or use the approved branch.
+
+Complete only the files named or clearly implied by the approved issue.
+
+Do not begin the next issue.
+Do not modify unrelated files.
+Do not include secrets, API keys, private client data, or backend-provider bypass paths.
+
+Open a PR into main, then stop.
+```
+
+---
+
+## Phase A Prompt — Core Knowledge Bases
+
+Use only after a specific Phase A issue is approved in `NEXT_TASK.md`.
+
+```text
+Use repository JFeimster/ai-agent-library.
+
+Read JULES.md, NEXT_TASK.md, and prompt-chains/grouped-task-sequence.md.
+
+Work only the Current Approved Task listed in NEXT_TASK.md.
+
+This task belongs to Phase A — Core Knowledge Bases.
+
+Allowed general folder:
+knowledge-base/
+
+Do not implement other Phase A issues unless explicitly included in the current approved issue.
+
+Preserve these boundaries:
+- #5 funding only
+- #6 partner enablement only
+- #7 engineering-as-marketing only
+- #8 CRM, automation, content ops, and local referrals only
+
+Use structured markdown with practical definitions, routing logic, use cases, guardrails, and crosslinks where appropriate.
+
+Do not include secrets, private client data, or backend-provider bypass paths.
+
+Open a PR into main, then stop.
+```
+
+---
+
+## Phase B Prompt — Data + Platform Expansion
+
+Use only after a specific Phase B issue is approved in `NEXT_TASK.md`.
+
+```text
+Use repository JFeimster/ai-agent-library.
+
+Read JULES.md, NEXT_TASK.md, and prompt-chains/grouped-task-sequence.md.
+
+Work only the Current Approved Task listed in NEXT_TASK.md.
+
+This task belongs to Phase B — Data + Platform Expansion.
+
+Allowed general folders:
+- schemas/
+- platforms/
+- templates/
+
+Do not implement other Phase B issues unless explicitly included in the current approved issue.
+
+Prefer machine-readable structure where useful.
+
+Do not add package managers, build systems, runtime dependencies, or unrelated web app code unless the approved issue explicitly asks for them.
+
+Open a PR into main, then stop.
+```
+
+---
+
+## Phase C Prompt — Portfolio + Roadmap Layer
+
+Use only after a specific Phase C issue is approved in `NEXT_TASK.md`.
+
+```text
+Use repository JFeimster/ai-agent-library.
+
+Read JULES.md, NEXT_TASK.md, and prompt-chains/grouped-task-sequence.md.
+
+Work only the Current Approved Task listed in NEXT_TASK.md.
+
+This task belongs to Phase C — Portfolio + Roadmap Layer.
+
+Allowed general folders:
+- portfolio/
+- roadmap/
+- examples/
+
+Do not invent URLs or project claims.
+If source data is missing, mark values as Unknown.
+
+Open a PR into main, then stop.
+```
+
+---
+
+## Phase D Prompt — Repo Hygiene + Final Crosslinks
+
+Use only after a specific Phase D issue is approved in `NEXT_TASK.md`.
+
+```text
+Use repository JFeimster/ai-agent-library.
+
+Read JULES.md, NEXT_TASK.md, and prompt-chains/grouped-task-sequence.md.
+
+Work only the Current Approved Task listed in NEXT_TASK.md.
+
+This task belongs to Phase D — Repo Hygiene + Final Crosslinks.
+
+Allowed general files/folders:
+- .github/
+- README.md
+- agents.md
+- agent-index.json
+- folder README files
+- crosslink/index files
+
+Do not rewrite core content unnecessarily.
+Prefer additive templates, checklists, crosslinks, and navigation improvements.
+
+Open a PR into main, then stop.
+```

--- a/prompt-chains/master-roadmap-prompt.md
+++ b/prompt-chains/master-roadmap-prompt.md
@@ -1,0 +1,80 @@
+# Master Roadmap Prompt
+
+Use this prompt in ChatGPT or another orchestration agent when continuing execution for this repository.
+
+```text
+This thread manages execution for JFeimster/ai-agent-library.
+
+Use GitHub connector as needed.
+
+Repo control files:
+- JULES.md
+- NEXT_TASK.md
+- prompt-chains/README.md
+- prompt-chains/grouped-task-sequence.md
+- prompt-chains/review-and-merge-checklist.md
+- prompt-chains/next-task-update-protocol.md
+
+Current operating rule:
+- NEXT_TASK.md controls the single approved Jules task.
+- Prompt chains can plan grouped work.
+- Implementation still happens through scoped PRs.
+- Do not combine unrelated tasks unless explicitly approved.
+
+Primary objective:
+Continue building the AI Agent Library from Issues #5–#16 using grouped prompt-chain sequencing while preserving PR-based review discipline.
+
+Known phase structure:
+
+Phase A — Core Knowledge Bases:
+- #5 Add Moonshine Capital funding knowledge base
+- #6 Add partner enablement knowledge base
+- #7 Add engineering-as-marketing knowledge base
+- #8 Add CRM, automation, content ops, and local referral knowledge bases
+
+Phase B — Data + Platform Expansion:
+- #9 Add schema definitions
+- #10 Expand platform implementation packs
+- #11 Expand reusable templates
+
+Phase C — Portfolio + Roadmap Layer:
+- #12 Add portfolio inventories
+- #13 Add roadmap folder
+- #14 Add agent usage examples
+
+Phase D — Repo Hygiene + Final Crosslinks:
+- #15 Add GitHub project hygiene files
+- #16 Add final indexes and crosslinks
+
+Execution instructions:
+1. Check current open PRs before creating new branches.
+2. Check NEXT_TASK.md before assigning Jules work.
+3. Keep each PR issue-scoped unless the user explicitly authorizes a grouped PR.
+4. When drafting work in ChatGPT, define exact files, branch, commit message, and stop condition.
+5. After a PR merges, update NEXT_TASK.md to the next approved issue.
+6. Do not include secrets, private client data, backend-provider bypass paths, or unapproved production automation actions.
+7. Prefer structured markdown, JSON, CSV, and reusable templates over vague planning documents.
+
+Current action requested:
+[INSERT USER REQUEST HERE]
+```
+
+## Use cases
+
+Use this prompt when:
+
+- A thread is slow and needs a clean continuation context.
+- Jules is blocked or slow, but planning can continue.
+- A new assistant needs the build sequence without reading the entire repo history.
+- A PR was merged and the next task needs to be queued.
+- A grouped phase needs to be decomposed into issue-scoped PRs.
+
+## Stop conditions
+
+Stop and ask for review when:
+
+- A PR is opened.
+- A task would modify unrelated folders.
+- Source data is missing.
+- A requested action could leak private data or secrets.
+- The next step requires choosing between multiple repo architecture patterns.

--- a/prompt-chains/next-task-update-protocol.md
+++ b/prompt-chains/next-task-update-protocol.md
@@ -1,0 +1,109 @@
+# Next Task Update Protocol
+
+Use this protocol after a PR is merged and the repo is ready to advance the queue.
+
+`NEXT_TASK.md` is the control file for Jules. Keep it boring, explicit, and narrow.
+
+## When to update
+
+Update `NEXT_TASK.md` only after:
+
+- The current PR has merged.
+- The completed issue is done or intentionally closed.
+- The next issue is selected by the user or confirmed by the roadmap.
+
+Do not update `NEXT_TASK.md` while a PR is still open unless the user explicitly wants to re-queue work.
+
+## Update rules
+
+- [ ] Set Current Approved Task to exactly one issue.
+- [ ] Include issue number.
+- [ ] Include issue title.
+- [ ] Include branch name.
+- [ ] Set status to `Ready for Jules`.
+- [ ] Remove the approved issue from Upcoming Tasks.
+- [ ] Preserve the reusable Jules prompt.
+- [ ] Do not add multiple current tasks.
+
+## Template
+
+```markdown
+# Next Task Queue
+
+This file tells Jules which single task is currently approved.
+
+## Current Approved Task
+
+Issue: #[NUMBER]  
+Title: [ISSUE TITLE]  
+Branch: `[BRANCH NAME]`  
+Status: Ready for Jules
+
+## Rule
+
+Jules should only work the Current Approved Task.
+
+After Jules opens a PR:
+
+- Stop.
+- Do not begin the next task.
+- Wait for human review, merge, and queue update.
+
+## Reusable Jules Prompt
+
+```text
+Use repository JFeimster/ai-agent-library.
+
+Read JULES.md and NEXT_TASK.md.
+
+Work only the Current Approved Task listed in NEXT_TASK.md.
+
+Follow the linked GitHub issue exactly.
+
+Create the branch, complete the task, commit changes, open a PR into main, then stop.
+
+Do not begin the next task.
+```
+
+## Upcoming Tasks
+
+1. #[NEXT] [TITLE]
+2. #[NEXT] [TITLE]
+```
+
+## Recommended issue order after #4
+
+If Issue #20 has not merged yet, consider queueing #20 before #5 so the prompt-chain system exists before the heavier knowledge-base buildout.
+
+Otherwise:
+
+1. #5 Add Moonshine Capital funding knowledge base
+2. #6 Add partner enablement knowledge base
+3. #7 Add engineering-as-marketing knowledge base
+4. #8 Add CRM, automation, content ops, and local referral knowledge bases
+5. #9 Add schema definitions
+6. #10 Expand platform implementation packs
+7. #11 Expand reusable templates
+8. #12 Add portfolio inventories
+9. #13 Add roadmap folder
+10. #14 Add agent usage examples
+11. #15 Add GitHub project hygiene files
+12. #16 Add final indexes and crosslinks
+
+## Commit message format
+
+```text
+Update next task to issue #[NUMBER]
+```
+
+## Final confirmation format
+
+```text
+NEXT_TASK.md updated to:
+
+Issue #[NUMBER] — [TITLE]
+Branch: [BRANCH]
+Status: Ready for Jules
+
+Commit: [SHA]
+```

--- a/prompt-chains/review-and-merge-checklist.md
+++ b/prompt-chains/review-and-merge-checklist.md
@@ -1,0 +1,109 @@
+# Review and Merge Checklist
+
+Use this checklist before approving, merging, or queue-advancing any PR in this repository.
+
+## 1. Confirm issue alignment
+
+- [ ] PR references the correct issue.
+- [ ] PR title matches the issue goal.
+- [ ] PR body explains what changed.
+- [ ] PR does not claim completion of unrelated issues.
+
+## 2. Check file scope
+
+- [ ] Changed files match the approved issue.
+- [ ] No future issue folders were started accidentally.
+- [ ] No source-data files were duplicated unnecessarily.
+- [ ] No build tooling, package managers, frameworks, or runtime dependencies were added unless explicitly approved.
+
+## 3. Check content safety
+
+- [ ] No API keys.
+- [ ] No secrets.
+- [ ] No private client data.
+- [ ] No unapproved provider/lender claims.
+- [ ] No backend-provider bypass paths.
+- [ ] No production automation actions.
+
+## 4. Check source-of-truth integrity
+
+- [ ] Generated indexes match source files.
+- [ ] Source files are referenced accurately.
+- [ ] Missing values are marked `Unknown` instead of invented.
+- [ ] Public-facing docs avoid private operational details.
+
+## 5. Check navigation and crosslinks
+
+- [ ] README links work or are clearly planned.
+- [ ] Folder README files point to the right child files.
+- [ ] Relative links are preferred over hardcoded repo URLs when possible.
+- [ ] New files are discoverable from an index or README when appropriate.
+
+## 6. Check merge readiness
+
+- [ ] No merge conflicts.
+- [ ] PR branch is up to date enough to merge cleanly.
+- [ ] CI/status checks pass if configured.
+- [ ] No accidental logs, temp files, screenshots, or local artifacts.
+
+## 7. Review decision
+
+### Approve when
+
+- Scope is correct.
+- Files are clean.
+- Content is useful.
+- No safety or data issues exist.
+- Any small nits are non-blocking.
+
+### Request changes when
+
+- PR includes unrelated future work.
+- Source data is duplicated or conflicting.
+- Files are in the wrong folder.
+- Private/sensitive details are present.
+- Generated indexes are stale or inconsistent.
+- README/crosslinks point to files that do not exist.
+
+## 8. Post-merge action
+
+After merge:
+
+1. Confirm the linked issue closed or manually close it if appropriate.
+2. Update `NEXT_TASK.md` to the next approved issue.
+3. Keep the next task narrow.
+4. Do not queue multiple Jules tasks at once unless the user explicitly changes the workflow.
+
+## PR comment template — approve
+
+```text
+Reviewed against Issue #[NUMBER].
+
+Recommended: merge.
+
+Confirmed:
+- Scope matches the approved issue.
+- Changed files are in scope.
+- No future issue work started.
+- No secrets, private client data, or backend-provider bypass details found.
+- Navigation/crosslinks are acceptable.
+
+After merge, update NEXT_TASK.md to Issue #[NEXT].
+```
+
+## PR comment template — request changes
+
+```text
+Reviewed against Issue #[NUMBER].
+
+Requesting changes before merge.
+
+Blocking items:
+1. [ITEM]
+2. [ITEM]
+
+Please fix only these items.
+Do not expand scope.
+Do not begin the next issue.
+Stop after pushing the revision for re-review.
+```


### PR DESCRIPTION
Fixes #20.

## Summary

Adds a repo-native prompt-chain control layer so grouped task planning can continue without breaking the one-issue-at-a-time PR workflow.

## Files added

- `prompt-chains/README.md`
- `prompt-chains/master-roadmap-prompt.md`
- `prompt-chains/grouped-task-sequence.md`
- `prompt-chains/jules-execution-prompts.md`
- `prompt-chains/chatgpt-execution-prompts.md`
- `prompt-chains/review-and-merge-checklist.md`
- `prompt-chains/next-task-update-protocol.md`

## Files updated

- `JULES.md` — references the prompt-chain control layer while preserving `NEXT_TASK.md` as the authority.
- `README.md` — links the new prompt-chain command layer.

## Validation checklist

- [x] Scope matches Issue #20.
- [x] Does not implement Issues #5–#16.
- [x] Preserves one-issue-at-a-time Jules workflow.
- [x] Adds phase grouping for Issues #5–#16.
- [x] Adds Jules and ChatGPT execution prompts.
- [x] Adds PR review and queue update protocols.
- [x] No secrets, private client data, or backend-provider bypass paths included.

## Stop condition

PR opened into `main`; no further issue work started.