### PR TITLE
Add Moonshine Capital funding knowledge base

### DIFF
--- a/knowledge-base/README.md
+++ b/knowledge-base/README.md
@@ -1,0 +1,41 @@
+# Knowledge Base
+
+This folder contains reusable source knowledge for AI agents, platform packs, workflows, and productized tools.
+
+Knowledge-base files are designed to be referenced by:
+
+- Agent specs in `agents/`
+- Platform packs in `platforms/`
+- Templates in `templates/`
+- Examples in `examples/`
+- Future schemas and validation workflows
+
+## Current sections
+
+```text
+knowledge-base/
+  funding/
+```
+
+## Rules
+
+- Keep internal routing logic separate from prospect-facing language.
+- Do not include private client data.
+- Do not include API keys, tokens, webhook secrets, or credentials.
+- Do not expose backend funding provider bypass paths.
+- Do not make funding, credit, legal, tax, investment, or approval guarantees.
+- Use clear white-labeled Moonshine Capital language unless a source explicitly approves naming a provider.
+
+## Expansion roadmap
+
+Planned sections include:
+
+```text
+knowledge-base/
+  partner-enablement/
+  engineering-as-marketing/
+  crm/
+  automation/
+  content-ops/
+  local-referrals/
+```

--- a/knowledge-base/funding/README.md
+++ b/knowledge-base/funding/README.md
@@ -1,0 +1,48 @@
+# Moonshine Capital Funding Knowledge Base
+
+This folder is the funding source layer for Moonshine Capital agents, tools, intake flows, and partner-facing workflows.
+
+The operating concept is simple: **intelligent routing, not application roulette**.
+
+Instead of treating every applicant like they belong in the same funnel, Moonshine Capital should collect enough qualification context to route prospects toward the most appropriate funding family, prep path, or follow-up workflow.
+
+## Files
+
+```text
+knowledge-base/funding/
+  funding-product-portfolio-summary.md
+  funding-product-family-map.md
+  qualification-bands.md
+  fast-disqualifiers.md
+  required-documents-by-product-family.md
+  intake-questions.md
+  prospect-facing-language.md
+  internal-routing-logic.md
+  white-label-language-rules.md
+```
+
+## Source basis
+
+This folder is based on Moonshine Capital funding strategy context, including available funding/SEO/marketing documents, existing repo operating rules, and known Moonshine Capital positioning around alternative small business funding, business credit, ecommerce funding, gig-worker funding, acquisition financing, same-day funding, and partner/broker recruitment.
+
+## Guardrails
+
+- No funding approval guarantees.
+- No credit score improvement guarantees.
+- No legal, tax, financial, or investment advice.
+- Keep underwriting/routing language directional, not absolute.
+- Keep backend/provider details out of prospect-facing copy unless explicitly approved.
+- Treat missing or uncertain values as `Unknown` instead of inventing precision.
+
+## Best-fit agent references
+
+This knowledge base is especially relevant for:
+
+- `agents/01-funding-pipeline-triage-agent.md`
+- `agents/02-incomplete-application-rescue-agent.md`
+- `agents/05-funding-tool-router-agent.md`
+- `agents/13-applicant-support-agent.md`
+- `agents/18-affiliate-offer-matchmaker.md`
+- `agents/19-business-credit-builder-coach.md`
+- `agents/20-cash-flow-copilot.md`
+- `agents/21-micro-acquisition-deal-screener.md`

--- a/knowledge-base/funding/fast-disqualifiers.md
+++ b/knowledge-base/funding/fast-disqualifiers.md
@@ -1,0 +1,73 @@
+# Fast Disqualifiers
+
+Fast disqualifiers help agents avoid wasting time, overpromising, or routing poor-fit prospects into the wrong flow.
+
+These are not legal or underwriting determinations. They are operational triage triggers.
+
+## Immediate no-go or redirect triggers
+
+| Trigger | Why it matters | Agent response |
+|---|---|---|
+| Consumer-only use of funds | Moonshine Capital funding workflows are business-use focused | Redirect to business-use clarification or consumer-finance disclaimer |
+| No verifiable business or income activity | Funding routes generally require some evidence of ability to repay | Offer readiness path instead of application push |
+| Refusal to verify identity | KYC/verification is basic funding hygiene | Stop and explain verification is required before routing |
+| Refusal to provide bank/revenue documentation | Revenue and deposit data drive routing | Provide document checklist; do not continue promising speed |
+| Request for guaranteed approval | Unsafe and non-compliant expectation | Explain no approval can be guaranteed |
+| Request to falsify documents or misrepresent revenue | Fraud risk | Stop and refuse assistance |
+| Unrealistic amount with weak support | Creates bad prospect experience and lender mismatch | Reset expectations and ask for revenue/use-case context |
+| Prohibited or illegal business activity | Compliance risk | Decline and do not route |
+| Active bankruptcy or severe unresolved legal issue | High-risk funding context | Escalate to manual review or readiness guidance |
+| Existing negative funding event with unclear status | Stacking/default risk | Ask for payoff/current status and escalate if needed |
+
+## Yellow-flag triggers
+
+Yellow flags do not automatically disqualify a prospect. They require clarification or manual review.
+
+- Business bank account is not active.
+- Revenue is deposited into multiple accounts.
+- Business name differs from bank account/entity records.
+- Prospect asks for funding urgently but cannot explain the use case.
+- Applicant is not the owner or authorized representative.
+- Revenue has major unexplained spikes or drops.
+- Prospect has only cash revenue with limited records.
+- Requested funding amount exceeds what the business activity appears to support.
+- Documents are screenshots instead of statements or official files.
+- Prospect wants to apply under another person’s identity or business.
+
+## Fast-disqualification response pattern
+
+Use this structure when declining or redirecting:
+
+```text
+Based on what you shared, this may not be the right funding route yet.
+
+The main blocker is: [reason].
+
+A better next step is: [readiness step / document step / manual review / alternative path].
+
+No funding decision has been made here. This is just a routing recommendation based on the information available.
+```
+
+## Examples
+
+### No verifiable revenue
+
+```text
+This does not look ready for a funding application yet because there is no verifiable revenue or business activity to review. The better move is to build a basic funding-readiness file first: business bank account, revenue tracking, entity details, and a short use-of-funds plan.
+```
+
+### Consumer use case
+
+```text
+This funding workflow is designed for business-use capital. If the funds are for personal expenses only, this is not the right path. If there is a business-use case, clarify the business, revenue source, and intended use of funds.
+```
+
+### Guaranteed approval request
+
+```text
+No legitimate funding workflow can promise approval before review. The right next step is to check fit, collect the required documents, and route the file based on verified details.
+```
+
+## Guardrail
+
+Do not use disqualifier language to shame the applicant. The goal is to protect the prospect, the brand, and the routing system.

--- a/knowledge-base/funding/funding-product-family-map.md
+++ b/knowledge-base/funding/funding-product-family-map.md
@@ -1,0 +1,61 @@
+# Funding Product Family Map
+
+Use this map to help agents classify a prospect into a funding family before recommending next steps.
+
+This is not underwriting. It is routing logic for intake, triage, education, and follow-up.
+
+## Family map
+
+| Family | Signal | Good fit when | Caution when | Useful next step |
+|---|---|---|---|---|
+| Working capital | Existing operating business needs cash | Business has active revenue and a clear use of funds | No business activity or unclear use of funds | Collect revenue, bank history, requested amount, and timeline |
+| Revenue-based funding | Deposits/sales can support payback | Consistent gross revenue, business bank or verifiable income stream | Deposits are irregular, very low, or unverifiable | Request bank statements or connection step |
+| Line of credit | Recurring need for flexible access | Business wants reusable capital, not a single lump-sum event | Prospect needs immediate emergency cash only | Ask about recurring cash-flow cycles and desired credit access |
+| Business credit path | Prospect needs fundability prep | Newer business, thin profile, wants larger future funding | Prospect needs cash today and has no immediate eligibility | Offer readiness roadmap and vendor/tradeline prep |
+| 0% credit / credit stacking | Strong credit posture supports card/credit strategy | Good personal credit, clean utilization, strategic use case | High utilization, recent late payments, weak personal profile | Ask about FICO band, utilization, recent inquiries, entity setup |
+| Ecommerce seller funding | Sales/inventory cycle drives funding need | Active online store/marketplace revenue | No sales history or unclear inventory plan | Collect platform, monthly sales, inventory turn, ad spend |
+| Gig/self-employed funding | Operator has recurring income but may lack traditional docs | Verifiable deposits from self-employed work | Funding request is consumer-use only | Frame as business-use funding and collect income proof |
+| Contractor/material financing | Job timing creates cash gap | Pending or active jobs, materials needed, invoices/estimates available | No active job, no quote, no repayment source | Request job details, estimate/invoice, deposits, timeline |
+| Acquisition financing | Prospect wants to buy or stabilize a business | Buyer has target business, deal terms, capital gap, or post-close need | No target, no financials, no plan | Ask for purchase price, seller terms, financials, down payment |
+| Grant/opportunity research | Prospect seeks non-repayable programs | Business fits grant category, geography, or mission criteria | Prospect needs guaranteed cash fast | Explain grants are competitive and slower; collect eligibility context |
+
+## Top-level routing questions
+
+1. Is this an existing business, startup, acquisition target, or self-employed operation?
+2. Is the need urgent cash, future credit readiness, inventory, payroll, materials, acquisition, or growth?
+3. Is revenue verifiable?
+4. How long has the business or income stream been active?
+5. Is the applicant using a business bank account, personal account, or marketplace platform?
+6. What documents can they provide now?
+7. Does the prospect need public education, an application link, or internal manual review?
+
+## Use-case-first routing
+
+Start with the job-to-be-done:
+
+- Need to cover payroll, rent, repairs, or short-term expenses → working capital or revenue-based funding.
+- Need recurring access → line of credit.
+- Need inventory/ad spend → ecommerce seller funding or working capital.
+- Need business credibility → business credit path.
+- Need startup runway with strong credit → 0%/credit-stacking style path.
+- Need job materials → contractor/material financing.
+- Need to buy a business → acquisition financing.
+- Need local/mission-based non-repayable funding → grant research path.
+
+## Agent output pattern
+
+A funding-routing agent should return:
+
+```text
+Primary fit: [Product family]
+Secondary fit: [Optional]
+Why: [Plain-language reason]
+Missing info: [Specific questions/docs]
+Next action: [Application, document upload, booking, readiness plan, or manual review]
+Public-safe copy: [Prospect-facing response]
+Internal note: [Routing rationale, not shown to prospect]
+```
+
+## Guardrail
+
+Do not present product family fit as approval, offer, quote, or binding term. It is a preliminary routing recommendation.

--- a/knowledge-base/funding/funding-product-portfolio-summary.md
+++ b/knowledge-base/funding/funding-product-portfolio-summary.md
@@ -1,0 +1,71 @@
+# Funding Product Portfolio Summary
+
+Moonshine Capital should present funding as a routing system, not a one-size-fits-all loan shelf.
+
+The portfolio is best understood as a set of product families that solve different capital problems for different business profiles.
+
+## Core positioning
+
+Moonshine Capital helps business owners, self-employed operators, founders, creators, real estate investors, ecommerce sellers, contractors, and gig workers explore practical funding paths without forcing them into a traditional bank-only framework.
+
+The emphasis is on:
+
+- Speed
+- Fit
+- Cash-flow context
+- Documentation readiness
+- Alternative/non-bank options
+- Business-use funding
+- Partner-assisted navigation
+
+## Product family overview
+
+| Product family | Primary job | Best-fit prospect | Typical use case | Public language |
+|---|---|---|---|---|
+| Working capital | Solve short-term cash-flow gaps | Existing business with revenue | Payroll, inventory, repairs, materials, operating cash | Flexible business funding based on current activity |
+| Revenue-based funding | Align capital access with gross revenue | Business with consistent deposits/sales | Same-day or fast operating capital | Funding that flexes with revenue |
+| Business line of credit | Provide reusable access to capital | Business needing ongoing liquidity | Inventory, receivables timing, seasonal needs | A flexible capital buffer |
+| Business credit / credit-building path | Improve future funding readiness | Thin-file or early-stage business | Vendor accounts, tradelines, credit profile prep | Build a more fundable business foundation |
+| 0% / credit-stacking style capital | Access promotional credit capacity | Strong personal credit / strategic use case | Startup runway, inventory, marketing spend | Strategic 0% capital options where qualified |
+| Ecommerce / online seller funding | Fund inventory and ad cycles | Shopify, Amazon, Walmart, TikTok Shop, ecommerce sellers | Inventory turns, ads, purchase orders | Capital for online sellers moving faster than banks |
+| Gig worker / self-employed funding | Support operator downtime and emergency expenses | Rideshare, delivery, contractors, freelancers | Repairs, equipment, insurance, working cash | Business-use funding for self-employed operators |
+| Contractor/material financing | Keep jobs moving | Trades, contractors, local service businesses | Materials, payroll, job deposits | Fast capital for materials and job cash-flow gaps |
+| Acquisition / bridge funding | Support purchase or post-close needs | Buyers and acquisition entrepreneurs | Down payment gaps, post-close working capital | Capital strategy for buying or stabilizing a business |
+| Grant / non-repayable opportunity research | Identify non-debt funding options | Innovation, nonprofit, local business, niche programs | Research and readiness | Find possible non-repayable funding opportunities |
+
+## Portfolio principles
+
+1. **Fit beats volume.** The goal is not to spray every applicant across every possible lender or partner.
+2. **Cash flow matters.** Revenue behavior, account history, deposits, and use case often matter more than generic labels.
+3. **Documentation determines speed.** Faster funding depends on complete, accurate intake and supporting documents.
+4. **Public copy should stay simple.** Prospects need clear next steps, not internal routing spaghetti.
+5. **Internal routing can be more granular.** Agent workflows may evaluate revenue bands, account type, time in business, credit posture, missing documents, and use case.
+
+## Do not promise
+
+Avoid saying:
+
+- Guaranteed approval
+- Guaranteed same-day funding
+- No documents required for everyone
+- Bad credit always accepted
+- No credit check ever
+- Everyone qualifies
+- Free money
+- Legal loophole
+
+Use safer language:
+
+- See what you may qualify for
+- Explore available funding paths
+- Funding timelines vary by product, readiness, and underwriting
+- Some options may be available quickly for qualified applicants
+- Approval and terms depend on verification, documentation, and funding partner requirements
+
+## Related files
+
+- `funding-product-family-map.md`
+- `qualification-bands.md`
+- `intake-questions.md`
+- `internal-routing-logic.md`
+- `prospect-facing-language.md`

--- a/knowledge-base/funding/intake-questions.md
+++ b/knowledge-base/funding/intake-questions.md
@@ -1,0 +1,129 @@
+# Funding Intake Questions
+
+Use these questions to help agents collect enough context to route prospects intelligently.
+
+The goal is not interrogation. The goal is to avoid application roulette.
+
+## Minimum viable intake
+
+1. What is your business name?
+2. What does the business do?
+3. Are you the owner or an authorized representative?
+4. How long has the business or income stream been active?
+5. What type of bank account receives the revenue: business, personal, or marketplace/platform account?
+6. What is your approximate monthly revenue or deposit volume?
+7. How much funding are you looking for?
+8. What will the funds be used for?
+9. How quickly do you need the funds?
+10. Can you provide recent bank statements or securely connect your bank account if required?
+
+## Qualification/context questions
+
+### Business profile
+
+- Entity type: sole proprietor, LLC, corporation, partnership, nonprofit, unknown?
+- State/location?
+- Industry?
+- Website or social profile?
+- Number of employees or contractors?
+- Existing business bank account?
+
+### Revenue and banking
+
+- Average monthly gross revenue?
+- Lowest recent revenue month?
+- Highest recent revenue month?
+- Number of deposits per month?
+- Any major unexplained revenue swings?
+- Primary revenue source?
+- Any existing advances, loans, or repayment obligations?
+
+### Funding request
+
+- Requested amount?
+- Minimum useful amount?
+- Deadline?
+- Primary use of funds?
+- Is this for payroll, inventory, materials, ads, repairs, equipment, tax, acquisition, debt consolidation, or general working capital?
+- Is the request urgent because of a job, invoice, repair, or missed opportunity?
+
+### Documentation readiness
+
+- Can you provide the last 3–6 months of bank statements if requested?
+- Do you have invoices, contracts, purchase orders, or estimates tied to the funding use?
+- Do you have government ID available for verification if needed?
+- Are business documents/entity records available?
+- Do business name, owner name, and bank records match?
+
+### Credit/business-credit context
+
+Ask only when relevant:
+
+- Do you know your approximate personal credit band?
+- Any recent late payments, collections, bankruptcy, or high utilization?
+- Does your business have vendor accounts or trade references?
+- Is the business address, phone, website, and entity information consistent?
+
+### Vertical-specific questions
+
+#### Ecommerce / online sellers
+
+- Which platform: Shopify, Amazon, Walmart, TikTok Shop, Etsy, other?
+- Monthly store revenue?
+- Inventory turn cycle?
+- Current ad spend?
+- Is the funding for inventory, ads, payroll, or fulfillment?
+
+#### Contractors / trades
+
+- What job or project is the funding tied to?
+- Do you have an estimate, invoice, purchase order, or contract?
+- What materials or payroll gap needs to be covered?
+- When does the job start or payment arrive?
+
+#### Gig/self-employed operators
+
+- Which platform or line of work produces income?
+- Is the funding for business-use expenses?
+- Are deposits visible in a bank account?
+- Is the need related to equipment, vehicle, insurance, supplies, or operating cash?
+
+#### Acquisition entrepreneurs
+
+- Are you buying a specific business?
+- Purchase price?
+- Revenue and cash flow of the target?
+- Seller financing available?
+- Down payment available?
+- Do you need acquisition capital, bridge capital, or post-close working capital?
+
+## Agent intake output format
+
+```text
+Applicant type: [Business / self-employed / ecommerce / contractor / acquisition / unknown]
+Funding use case: [Use]
+Requested amount: [Amount]
+Revenue band: [Known/unknown]
+Document readiness: [Ready / partial / missing]
+Primary route: [Product family]
+Missing questions: [List]
+Next action: [Application / docs / booking / readiness / manual review]
+```
+
+## Public-safe framing
+
+Use:
+
+```text
+I need a few details so we can point you toward the most relevant funding path instead of forcing you through the wrong application.
+```
+
+Avoid:
+
+```text
+Answer these and we will get you approved.
+```
+
+## Guardrail
+
+If the applicant refuses basic identity, business, or revenue questions, do not continue routing. Offer a general education path instead.

--- a/knowledge-base/funding/internal-routing-logic.md
+++ b/knowledge-base/funding/internal-routing-logic.md
@@ -1,0 +1,148 @@
+# Internal Routing Logic
+
+This file is for internal agents, CRM workflows, intake triage, and partner-support operations.
+
+Do not reuse this file as public-facing website copy.
+
+## Routing philosophy
+
+Moonshine Capital should route prospects by fit, not hope.
+
+The basic sequence is:
+
+```text
+Intake → classify applicant → identify use case → check readiness → request missing docs → route to application/readiness/manual review → follow up
+```
+
+## Primary routing dimensions
+
+1. Applicant type
+2. Use of funds
+3. Revenue/deposit profile
+4. Time in business or activity history
+5. Bank account type
+6. Documentation readiness
+7. Credit posture when relevant
+8. Urgency/timeline
+9. Existing obligations or risk flags
+10. Public-safe messaging path
+
+## Routing decision tree
+
+### Step 1 — Classify applicant
+
+```text
+IF existing business with revenue → business funding route
+ELSE IF self-employed/gig operator with verifiable income and business-use need → self-employed/gig route
+ELSE IF ecommerce seller with platform revenue → ecommerce route
+ELSE IF contractor/tradesperson with job/material need → contractor/material route
+ELSE IF acquisition buyer with target deal → acquisition route
+ELSE IF no active business/revenue → readiness route
+ELSE manual review
+```
+
+### Step 2 — Classify use case
+
+```text
+IF payroll/materials/repairs/operating cash → working capital or revenue-based funding
+IF recurring capital buffer → line of credit
+IF inventory/ad spend/platform sales → ecommerce seller funding
+IF entity/credit foundation issue → business credit path
+IF startup runway and strong credit posture → 0%/credit-based route
+IF business purchase/post-close gap → acquisition/bridge strategy
+IF non-repayable capital request → grant/opportunity research
+```
+
+### Step 3 — Check readiness
+
+```text
+IF clear use case + verifiable revenue + documents ready → Band A
+IF likely fit but missing docs/details → Band B
+IF not fundable now but can improve → Band C
+IF conflicting info or unusual risk → Band D
+IF non-business use/prohibited/fraud risk → Band E
+```
+
+### Step 4 — Determine next action
+
+| Band | Next action |
+|---|---|
+| A | Send application, request final docs, or book funding review |
+| B | Send missing-doc checklist and follow-up task |
+| C | Send readiness roadmap and nurture sequence |
+| D | Escalate to manual review with notes |
+| E | Decline/redirect safely |
+
+## Internal notes format
+
+Use structured notes:
+
+```text
+Applicant type: [business/self-employed/ecommerce/contractor/acquisition/unknown]
+Use case: [working capital/materials/inventory/acquisition/etc.]
+Revenue signal: [known/unknown + band]
+Banking signal: [business/personal/platform/unknown]
+Docs: [ready/partial/missing]
+Readiness band: [A/B/C/D/E]
+Primary route: [product family]
+Secondary route: [optional]
+Risk flags: [list]
+Next action: [application/docs/readiness/manual review]
+Public-safe response: [short copy]
+```
+
+## Follow-up triggers
+
+Create a follow-up task when:
+
+- Application started but not completed.
+- Bank connection or bank statements are missing.
+- Identity verification is incomplete.
+- Use of funds is unclear.
+- Prospect is Band B and missing only a few items.
+- Prospect is Band C and should be nurtured into readiness.
+- Manual review is required.
+
+## Priority scoring
+
+| Signal | Priority impact |
+|---|---|
+| Urgent business-use need with verifiable revenue | High |
+| Complete docs and clear use case | High |
+| Contractor/material or repair deadline | High |
+| Ecommerce inventory cycle with active sales | High |
+| Missing only bank statements | Medium-high |
+| Needs business credit/readiness path | Medium |
+| No revenue or unclear business activity | Low |
+| Non-business use | No route / redirect |
+
+## White-label boundary
+
+Internal routing may mention product families, route types, and operational next steps.
+
+Prospect-facing language should not expose backend provider names, private partner logic, or internal routing shorthand unless explicitly approved.
+
+## Agent guardrail
+
+Agents must not:
+
+- Say the applicant is approved.
+- Quote exact rates or terms unless sourced and approved.
+- Represent a routing recommendation as a funding offer.
+- Reveal backend/provider bypass paths.
+- Encourage document manipulation.
+- Provide legal, tax, investment, or financial advice.
+
+## Better internal wording
+
+Use:
+
+```text
+Likely route based on current intake: revenue-based working capital. Missing: bank statements and use-of-funds detail. Public response should invite document upload and clarify no approval decision has been made.
+```
+
+Avoid:
+
+```text
+Approved for same-day funding. Send to provider X.
+```

--- a/knowledge-base/funding/prospect-facing-language.md
+++ b/knowledge-base/funding/prospect-facing-language.md
@@ -1,0 +1,120 @@
+# Prospect-Facing Language
+
+This file contains public-safe language for Moonshine Capital funding agents, pages, forms, emails, and chat flows.
+
+Prospect-facing language should be simple, credible, and white-labeled.
+
+## Core positioning
+
+```text
+Moonshine Capital helps business owners and self-employed operators explore funding paths based on their actual situation — revenue, timeline, use of funds, documentation, and readiness — instead of forcing everyone through the same generic loan application.
+```
+
+## Short homepage-style copy
+
+```text
+Get pointed toward the funding path that actually fits.
+
+Tell us what you need capital for, how your business earns revenue, and how quickly you need answers. We’ll help you identify the next best step — application, document prep, readiness work, or a better-fit funding route.
+```
+
+## Speed-focused copy
+
+```text
+Some qualified applicants may be able to move quickly when the file is complete and the funding path fits. Timelines vary based on documentation, verification, underwriting, and funding partner requirements.
+```
+
+## Revenue-based copy
+
+```text
+For many business owners, cash flow tells a better story than a traditional bank checklist. We look at the full picture — revenue, deposits, business activity, and use of funds — to help identify practical funding paths.
+```
+
+## Thin-credit copy
+
+```text
+A thin or imperfect credit profile does not automatically mean there is no path forward. The right route depends on revenue, documentation, business activity, and the type of funding you need.
+```
+
+## Documentation copy
+
+```text
+The fastest files are usually the cleanest files. Having recent bank statements, clear use of funds, accurate business details, and owner verification ready can reduce friction and help the review process move faster.
+```
+
+## Business credit readiness copy
+
+```text
+If funding is not the right fit today, the next move may be building a stronger business credit and funding-readiness foundation. That can include entity cleanup, business banking, vendor accounts, documentation, and clearer revenue tracking.
+```
+
+## Local/construction/gig-worker copy
+
+```text
+When a job, repair, payroll run, or material order cannot wait for a bank committee, fast-fit funding guidance matters. Moonshine Capital helps contractors, gig workers, self-employed operators, and local businesses understand which funding path may match the urgency and documentation they have now.
+```
+
+## Ecommerce copy
+
+```text
+Online sellers often need capital before the next inventory turn, ad cycle, or marketplace payout. We help ecommerce operators think through funding fit based on sales history, platform revenue, inventory needs, and cash-flow timing.
+```
+
+## Acquisition copy
+
+```text
+Buying a business is not just about finding capital. It is about matching the deal structure, seller terms, cash flow, and post-close working capital needs to the right funding strategy.
+```
+
+## CTA options
+
+Use CTAs like:
+
+- Check funding fit
+- Start funding intake
+- See possible funding paths
+- Build your funding-readiness file
+- Get routed to the right next step
+- Book a funding strategy call
+- Upload documents for review
+
+Avoid CTAs like:
+
+- Get guaranteed approval
+- Get funded no matter what
+- Free money today
+- No docs needed
+- Everyone qualifies
+- Beat every lender guaranteed
+
+## FAQ-safe language
+
+### Do I qualify?
+
+```text
+Qualification depends on the funding path, your business activity, revenue, documentation, credit posture when relevant, and the intended use of funds. The best first step is to complete the intake so we can identify the most relevant route.
+```
+
+### How fast can I get funded?
+
+```text
+Funding speed varies. Some qualified applicants may move quickly when documentation is complete and the route fits, but timelines depend on verification, review, and funding partner requirements.
+```
+
+### Is this a loan?
+
+```text
+Different funding paths work differently. Some are loan products, some are revenue-based or credit-based structures, and some are readiness or business-credit strategies. The intake helps determine which path is most relevant.
+```
+
+### Can bad credit still work?
+
+```text
+Credit is one factor, but it is not the only factor. Depending on the route, revenue, deposits, documentation, and business activity may also matter. If funding is not a fit today, a readiness plan may still help.
+```
+
+## Required disclaimer
+
+```text
+Moonshine Capital does not guarantee approval, funding amounts, rates, terms, or timelines. Funding availability depends on eligibility, documentation, verification, underwriting, and funding partner requirements. Information provided is for educational and routing purposes only and is not legal, tax, investment, or financial advice.
+```

--- a/knowledge-base/funding/qualification-bands.md
+++ b/knowledge-base/funding/qualification-bands.md
@@ -1,0 +1,87 @@
+# Qualification Bands
+
+Qualification bands help agents explain funding readiness without pretending to underwrite.
+
+These are directional triage bands, not approval criteria.
+
+## Band overview
+
+| Band | Description | Likely route | Agent action |
+|---|---|---|---|
+| A — Ready to route | Prospect has clear use case, verifiable revenue, basic documents, and reasonable timeline | Funding application or product-specific intake | Move to application/document step |
+| B — Needs light prep | Prospect looks potentially fundable but missing key details or documents | Follow-up, document checklist, bank connection, clarification | Ask targeted questions and set next task |
+| C — Readiness path | Prospect may not be fundable today but can improve readiness | Business credit, documentation cleanup, revenue organization, follow-up sequence | Provide prep roadmap |
+| D — Manual review | Conflicting data, unusual use case, unclear structure, or risky language | Human review | Escalate with notes |
+| E — Not a fit now | Non-business use, no verifiable activity, unrealistic request, or prohibited/risky ask | Decline/redirect | Provide safe alternative or readiness guidance |
+
+## Common readiness signals
+
+### Stronger signals
+
+- Existing business or self-employed activity.
+- Verifiable revenue or deposits.
+- Clear use of funds.
+- Bank statements or secure bank connection available.
+- Entity and owner identity can be verified.
+- Requested amount roughly matches revenue capacity.
+- Prospect understands funding is subject to review.
+
+### Weaker signals
+
+- No revenue or unverifiable revenue.
+- Consumer-only use case.
+- No documents available.
+- High urgency with no supporting information.
+- Unrealistic requested amount.
+- Conflicting business name, owner name, or banking details.
+- Refusal to verify identity or provide basic documentation.
+
+## Revenue/activity bands
+
+Use these as internal triage descriptions, not hard rules.
+
+| Band | Description | Example interpretation |
+|---|---|---|
+| No verified activity | No clear business or income stream evidence | Route to readiness or manual review |
+| Early activity | Some deposits/sales but limited history | Ask for more context, docs, and timeline |
+| Emerging cash flow | Verifiable ongoing income with some consistency | Potential fast-funding or working-capital route if docs support it |
+| Established cash flow | Consistent business revenue and documented operating history | Broader product-family exploration |
+| High-volume activity | Strong revenue volume and clear business operations | Consider multiple options and manual review for best fit |
+
+## Time-in-business bands
+
+| Band | Meaning | Routing note |
+|---|---|---|
+| Pre-launch | Idea stage or no active operations | Readiness roadmap, business credit prep, startup education |
+| 0–3 months | Very new activity | Limited options; ask about personal credit, revenue, and docs |
+| 4–12 months | Emerging operating history | Some alternative funding routes may open if revenue is verifiable |
+| 12–24 months | More mature activity | Broader funding discussions may be appropriate |
+| 24+ months | Established history | More product families may fit depending on revenue and docs |
+
+## Credit posture bands
+
+Do not ask agents to make credit decisions. Use credit posture only as a routing clue.
+
+| Band | Public-safe label | Routing note |
+|---|---|---|
+| Strong credit posture | Strong credit profile | May support credit-based or hybrid funding options |
+| Mixed credit posture | Some credit challenges | Consider revenue-based or documentation-focused options |
+| Thin file | Limited credit history | Normalize the issue and route to cash-flow or business-credit prep |
+| Damaged credit posture | Significant credit issues | Avoid guarantees; emphasize readiness and alternative review |
+| Unknown | Not provided | Ask only if relevant to product family |
+
+## Required output for agents
+
+When using qualification bands, return:
+
+```text
+Readiness band: [A/B/C/D/E]
+Reason: [2-4 bullets]
+Missing info: [Specific items]
+Recommended next step: [Application/docs/readiness/manual review]
+Prospect-safe explanation: [No guarantees]
+```
+
+## Guardrail
+
+Never say a prospect is approved based only on a band. A band is a routing aid, not a funding decision.

--- a/knowledge-base/funding/required-documents-by-product-family.md
+++ b/knowledge-base/funding/required-documents-by-product-family.md
@@ -1,0 +1,70 @@
+# Required Documents by Product Family
+
+Document requirements vary by product, funding partner, and applicant profile. This file gives agents a clean checklist structure without pretending every product has identical requirements.
+
+## Universal baseline
+
+Most funding routes require some combination of:
+
+- Legal business name
+- Owner name
+- Contact information
+- Business address
+- Entity type
+- Industry
+- Time in business
+- Requested amount
+- Use of funds
+- Monthly revenue estimate
+- Bank account type
+- Government ID / identity verification when required
+- Bank statements or secure bank connection when required
+
+## Product-family checklist
+
+| Product family | Common documents/data | Optional supporting docs | Notes |
+|---|---|---|---|
+| Working capital | Application, bank statements or bank connection, revenue estimate, use of funds | Invoices, receivables, tax return, P&L | Prioritize proof of active revenue and repayment source |
+| Revenue-based funding | Bank statements or secure bank connection, gross revenue, deposit consistency, owner verification | Processing statements, platform sales reports | Revenue behavior is usually more important than perfect traditional docs |
+| Business line of credit | Application, bank statements, owner/business details, credit posture if relevant | Tax returns, financial statements, debt schedule | Clarify whether prospect needs revolving access or one-time funding |
+| Business credit path | Entity details, EIN, business address, business bank account, existing vendor/tradeline details | D-U-N-S info, business credit reports, website, business phone | Often a readiness workflow, not immediate cash funding |
+| 0% / credit-stacking style capital | Personal credit posture, income/revenue, entity details, requested use case | Existing card limits, utilization, inquiry count | Avoid promising limits or approvals |
+| Ecommerce seller funding | Store/platform name, monthly sales, bank statements, seller dashboard data | Inventory reports, ad spend, SKU/product info | Ask about marketplace and inventory cycle |
+| Gig/self-employed funding | Income deposits, bank statements, platform earnings, business-use explanation | Vehicle/equipment docs, insurance, repair invoice | Keep framing business-use and self-employed operations |
+| Contractor/material financing | Job details, invoice/estimate, bank statements, requested material amount | Contracts, purchase orders, receivables, photos/permits | Useful for urgent material or payroll gaps |
+| Acquisition financing | Target business details, purchase price, financials, LOI/APA if available, buyer profile | Seller note terms, down payment proof, cash-flow analysis | Often needs manual review and deal-specific analysis |
+| Grant/opportunity research | Business profile, location, industry, owner demographics if voluntarily provided, project purpose | Certifications, proposal draft, budget, impact statement | Grants are competitive and slower; do not frame as fast cash |
+
+## Document status labels
+
+Agents should use these labels consistently:
+
+| Status | Meaning |
+|---|---|
+| `not-requested` | No request has been made yet |
+| `requested` | Applicant has been asked for this item |
+| `received` | Item appears to be submitted |
+| `needs-review` | Item may be incomplete or unclear |
+| `missing` | Required item has not been provided |
+| `not-applicable` | Item does not apply to the route |
+| `unknown` | Not enough information yet |
+
+## Missing-document response template
+
+```text
+You may still have a path forward, but the file is not ready to route yet.
+
+The missing items are:
+- [Document 1]
+- [Document 2]
+
+Once those are provided, the next step is to review fit and determine which funding family makes the most sense.
+```
+
+## Guardrails
+
+- Do not tell applicants to edit or alter documents.
+- Do not accept screenshots as automatically sufficient unless a workflow explicitly allows them.
+- Do not ask for sensitive documents unless needed for the specific route.
+- Do not store private client data in repo docs.
+- Do not claim that providing documents guarantees approval.

--- a/knowledge-base/funding/white-label-language-rules.md
+++ b/knowledge-base/funding/white-label-language-rules.md
@@ -1,0 +1,131 @@
+# White-Label Language Rules
+
+Moonshine Capital funding content should be written as Moonshine Capital guidance unless a specific backend/provider name is explicitly approved for the asset.
+
+## Default rule
+
+Use public-facing Moonshine Capital language.
+
+Do not expose backend providers, lender-specific bypass paths, private routing labels, or affiliate mechanics in prospect-facing copy.
+
+## Why this matters
+
+White-label discipline protects:
+
+- Brand clarity
+- Partner relationships
+- Applicant trust
+- Compliance posture
+- Future routing flexibility
+- SEO and conversion consistency
+
+## Public-facing language
+
+Use terms like:
+
+- funding path
+- funding partner
+- funding route
+- capital option
+- business funding option
+- working capital route
+- revenue-based funding option
+- business credit readiness path
+- document review
+- funding-fit check
+- application review
+
+Avoid terms like:
+
+- backend provider
+- hidden lender
+- bypass route
+- inside lane
+- guaranteed funding source
+- provider-specific internal product name
+- commission-driven route
+- secret approval path
+
+## Approved public framing
+
+```text
+Moonshine Capital helps route business owners toward funding paths that fit their revenue, documentation, timeline, and use of funds.
+```
+
+```text
+Different funding paths have different requirements. The intake helps identify which next step is most relevant.
+```
+
+```text
+Some routes may move faster when the file is complete and the applicant meets the relevant requirements.
+```
+
+## Internal-only framing
+
+The following should stay internal unless explicitly approved:
+
+- Provider-specific decision trees
+- Partner payout logic
+- Affiliate commission rules
+- Backend route names
+- Manual override notes
+- Private referral links
+- Internal CRM labels
+- Provider comparison notes not intended for prospects
+
+## Provider naming rule
+
+Only name a backend provider publicly when all three are true:
+
+1. The user explicitly approves naming the provider.
+2. The content is meant to discuss or compare that provider.
+3. The claim is accurate, sourced, and not overstated.
+
+If not, use a generic label:
+
+```text
+funding partner
+```
+
+or:
+
+```text
+available funding route
+```
+
+## Disclosure rule
+
+Affiliate, referral, broker, and compensation disclosures should be clear where required, but they do not need to expose private operational routing logic.
+
+Example:
+
+```text
+Moonshine Capital may receive compensation when applicants or partners use certain services or funding routes. This does not change the requirement that funding availability, terms, and timelines depend on review and eligibility.
+```
+
+## Prospect-safe replacement table
+
+| Internal phrase | Prospect-safe phrase |
+|---|---|
+| Send to backend provider | Route to the relevant funding path |
+| Provider requires bank link | This route may require bank verification |
+| Bigger funding lane | Larger funding path or expanded capital review |
+| Fast cash route | Fast-fit funding review |
+| Declined by lender | Not a fit for that funding path at this time |
+| Manual underwriting | Additional review |
+| Commission product | Partner-supported funding option |
+| Stacking | Layered capital strategy, if appropriate |
+
+## Guardrails
+
+- Do not imply Moonshine Capital is the direct lender unless explicitly true for the specific product.
+- Do not imply all applicants receive the same timeline.
+- Do not imply all funding products are loans.
+- Do not imply all funding products are non-dilutive without context.
+- Do not imply no credit check unless the specific route truly supports that statement and the claim is approved.
+
+## Default disclaimer
+
+```text
+Moonshine Capital helps applicants explore funding paths and readiness strategies. Funding availability, amounts, terms, costs, and timelines depend on eligibility, documentation, verification, underwriting, and funding partner requirements. Nothing here is a guarantee of approval or a substitute for legal, tax, financial, or investment advice.
+```


### PR DESCRIPTION
Fixes #5.

## Summary

Adds the Moonshine Capital funding knowledge base as a structured source layer for funding agents, routing workflows, intake flows, and prospect-safe language.

## Files added

- `knowledge-base/README.md`
- `knowledge-base/funding/README.md`
- `knowledge-base/funding/funding-product-portfolio-summary.md`
- `knowledge-base/funding/funding-product-family-map.md`
- `knowledge-base/funding/qualification-bands.md`
- `knowledge-base/funding/fast-disqualifiers.md`
- `knowledge-base/funding/required-documents-by-product-family.md`
- `knowledge-base/funding/intake-questions.md`
- `knowledge-base/funding/prospect-facing-language.md`
- `knowledge-base/funding/internal-routing-logic.md`
- `knowledge-base/funding/white-label-language-rules.md`

## Validation checklist

- [x] Scope matches Issue #5.
- [x] Internal routing logic is separated from prospect-facing language.
- [x] Public-facing language is white-labeled under Moonshine Capital.
- [x] No backend provider names or bypass paths exposed in public-facing examples.
- [x] Includes no-approval-guarantee and no legal/tax/financial advice guardrails.
- [x] Emphasizes intelligent routing, not application roulette.
- [x] Does not modify unrelated platform, portfolio, or prompt-chain files.
- [x] Does not begin Issue #6 or later.

## Notes

The exact files named in Issue #5 were not found in the repo by title, so this PR uses the available Moonshine Capital funding strategy context and the repo's existing safety/white-labeling rules to create a conservative knowledge base scaffold.

## Stop condition

PR opened into `main`; no further issue work started.