### PR TITLE
Add partner enablement knowledge base

### DIFF
--- a/knowledge-base/partner-enablement/README.md
+++ b/knowledge-base/partner-enablement/README.md
@@ -1,0 +1,60 @@
+# Partner Enablement Knowledge Base
+
+This folder contains Moonshine Capital partner enablement rules, routing logic, attribution models, microsite guidance, and resource-card standards.
+
+The core operating principle:
+
+> Partners share front-end assets. Moonshine Capital owns attribution, lead capture, routing, backend fulfillment, and follow-up.
+
+## Files
+
+```text
+knowledge-base/partner-enablement/
+  partner-lead-generation-strategy.md
+  partner-routing-attribution-spec.md
+  partner-link-tracking-model.md
+  partner-microsite-playbook.md
+  affiliate-protection-rules.md
+  partner-launch-kit-source-notes.md
+  broker-profile-resource-card-rules.md
+```
+
+## Default partner flow
+
+```text
+Partner shares Moonshine-controlled asset
+→ prospect lands on tracked Moonshine page/tool/profile
+→ attribution is captured
+→ intake or lead capture occurs
+→ lead is routed by intent/profile
+→ Moonshine handles backend fulfillment and follow-up
+```
+
+## Required tracking parameters
+
+- `partner_id`
+- `campaign_id`
+- `asset_id`
+- `vertical`
+- `product_intent`
+- `page_type`
+- `utm_source`
+- `utm_medium`
+- `utm_campaign`
+
+## Protection rules
+
+- Never expose backend providers publicly.
+- Never use provider names in public slugs or metadata.
+- Never send affiliates to raw backend pages first.
+- Use Moonshine-controlled pages as the first-click destination.
+- Keep partner links trackable, white-labeled, and operationally recoverable.
+
+## Relevant agent specs
+
+- `agents/03-partner-launch-kit-builder.md`
+- `agents/04-broker-profile-builder.md`
+- `agents/05-funding-tool-router-agent.md`
+- `agents/09-partner-training-coach.md`
+- `agents/10-local-referral-partner-scout.md`
+- `agents/18-affiliate-offer-matchmaker.md`

--- a/knowledge-base/partner-enablement/affiliate-protection-rules.md
+++ b/knowledge-base/partner-enablement/affiliate-protection-rules.md
@@ -1,0 +1,128 @@
+# Affiliate Protection Rules
+
+These rules protect Moonshine Capital, affiliate partners, referral partners, broker relationships, and prospect attribution.
+
+The system should make it easy for partners to share front-end assets while keeping routing, fulfillment, and backend operations controlled.
+
+## Non-negotiable rules
+
+1. Never expose backend providers publicly.
+2. Never use provider names in public slugs or metadata unless explicitly approved.
+3. Never send affiliates to raw backend pages first.
+4. Use Moonshine-controlled pages as the first-click destination.
+5. Preserve partner attribution through URL parameters, hidden fields, and CRM records.
+6. Keep partner-facing copy truthful and non-guaranteed.
+7. Keep internal routing logic separate from public partner enablement copy.
+
+## First-click protection
+
+Partner traffic should land first on:
+
+- Broker profile pages
+- Moonshine landing pages
+- Moonshine tools/calculators
+- Moonshine application bridge pages
+- Moonshine resource hubs
+
+Do not make the first click an uncontrolled outbound destination.
+
+## Attribution protection
+
+Every partner campaign should include:
+
+```text
+partner_id
+campaign_id
+asset_id
+vertical
+product_intent
+page_type
+utm_source
+utm_medium
+utm_campaign
+```
+
+The minimum partner-credit rule:
+
+```text
+If partner_id is present on first touch, preserve it as first_partner_id unless manually corrected by an authorized operator.
+```
+
+## Public metadata rules
+
+Do not include private operational details in:
+
+- URL slugs
+- SEO titles
+- Meta descriptions
+- Open Graph titles/descriptions
+- Image alt text
+- Public schema markup
+- Button labels
+- Public resource card titles
+
+## Approved public language
+
+Use:
+
+```text
+Powered by Moonshine Capital
+Funding-fit tool
+Partner resource
+Business funding path
+Application bridge
+Resource hub
+```
+
+Avoid:
+
+```text
+Backend provider route
+Provider direct page
+Secret funding lane
+Guaranteed approval partner
+Raw lender portal
+```
+
+## Partner claims guardrails
+
+Partners should not claim:
+
+- Guaranteed approval
+- Guaranteed terms
+- Guaranteed timeline
+- No documents required for everyone
+- Everyone qualifies
+- They personally approve funding
+- Moonshine Capital is the direct lender unless explicitly true for that product
+
+## Partner-safe explanation
+
+```text
+I share Moonshine Capital-powered tools and resources that help business owners identify possible funding paths. The actual review, routing, and follow-up are handled through Moonshine Capital’s system.
+```
+
+## Escalation triggers
+
+Escalate if a partner:
+
+- Changes approved links.
+- Removes attribution parameters.
+- Sends traffic directly to unapproved destinations.
+- Uses backend provider names publicly.
+- Promises approval or funding timelines.
+- Publishes misleading earnings or funding claims.
+- Uses private internal training language in public ads.
+
+## Enforcement options
+
+- Correct the asset/link.
+- Replace the partner’s swipe copy.
+- Pause the campaign.
+- Disable a tracked redirect.
+- Mark the partner for manual review.
+- Remove public access to an outdated resource.
+
+## Principle
+
+Protecting attribution is not bureaucracy. It is how the system keeps partners paid, prospects routed, and the brand from becoming a carnival booth with a loan button.

--- a/knowledge-base/partner-enablement/broker-profile-resource-card-rules.md
+++ b/knowledge-base/partner-enablement/broker-profile-resource-card-rules.md
@@ -1,0 +1,153 @@
+# Broker Profile Resource Card Rules
+
+Broker profile resource cards are curated front-end assets shown on partner or broker pages.
+
+They should help prospects take the right next step while preserving attribution and keeping routing controlled.
+
+## Resource card purpose
+
+A resource card should:
+
+- Match the broker’s audience.
+- Solve a specific prospect problem.
+- Route to a Moonshine-controlled destination.
+- Preserve attribution parameters.
+- Avoid exposing private backend/provider details.
+- Create a clean handoff into intake, tool usage, booking, or education.
+
+## Recommended card fields
+
+```json
+{
+  "title": "",
+  "description": "",
+  "buttonText": "",
+  "url": "",
+  "slug": "",
+  "resourceType": "",
+  "audience": [],
+  "problemSolved": "",
+  "bestFor": "",
+  "estimatedTimeToUse": "",
+  "sortOrder": 0,
+  "tags": []
+}
+```
+
+## Resource types
+
+Use consistent resource types:
+
+| Type | Use |
+|---|---|
+| `tool` | Calculator, interactive widget, GPT-style assistant, estimator |
+| `guide` | Article, PDF, checklist, framework |
+| `application` | Application bridge or intake form |
+| `booking` | Strategy call or support booking |
+| `landing-page` | Campaign-specific page |
+| `training` | Partner/broker education |
+| `resource-hub` | Curated resource collection |
+
+## Card title rules
+
+Good titles:
+
+- Funding Fit Checker
+- Trucker Repair-to-Revenue Tracker
+- Business Credit Readiness Guide
+- Contractor Materials Funding Checklist
+- Ecommerce Inventory Cash-Flow Tool
+
+Avoid titles that:
+
+- Name private providers.
+- Promise approval.
+- Imply guaranteed funding.
+- Use internal route labels.
+- Sound like a generic junk drawer.
+
+## Description rules
+
+Descriptions should answer:
+
+1. Who is this for?
+2. What problem does it solve?
+3. What should the prospect do next?
+
+Example:
+
+```text
+For contractors who need to understand whether a material or payroll gap is a funding-fit issue. Use this checklist before starting an intake.
+```
+
+## Button text rules
+
+Use action-driven labels:
+
+- Use the tool
+- Check funding fit
+- Start intake
+- View guide
+- Book a call
+- Compare next steps
+
+Avoid:
+
+- Guaranteed approval
+- Get funded no matter what
+- Secret lender access
+- Provider direct link
+
+## Attribution rule
+
+Every card URL should preserve:
+
+```text
+partner_id
+campaign_id
+asset_id
+vertical
+product_intent
+page_type
+utm_source
+utm_medium
+utm_campaign
+```
+
+## Card selection model
+
+Each broker profile should include:
+
+- 1 primary funding/intake CTA
+- 1–2 audience-specific tools
+- 1 readiness or education guide
+- 1 booking or support link when appropriate
+- Optional partner training card if the page is partner-facing
+
+## Sort order guideline
+
+| Sort order | Card role |
+|---:|---|
+| 1 | Primary conversion action |
+| 2 | Best audience-specific tool |
+| 3 | Secondary tool or guide |
+| 4 | Readiness checklist |
+| 5 | Booking/support |
+| 6+ | Additional resources |
+
+## Public safety checklist
+
+Before publishing a card:
+
+- [ ] Title is public-safe.
+- [ ] Description does not expose private routing details.
+- [ ] URL is Moonshine-controlled or approved.
+- [ ] Attribution parameters are present.
+- [ ] Button text avoids guarantees.
+- [ ] Resource type uses standard vocabulary.
+- [ ] Audience tags are useful and not overly broad.
+- [ ] The card fits the broker’s actual audience.
+
+## Principle
+
+A resource card should feel like a useful next step, not a desperate link buffet.

--- a/knowledge-base/partner-enablement/partner-launch-kit-source-notes.md
+++ b/knowledge-base/partner-enablement/partner-launch-kit-source-notes.md
@@ -1,0 +1,105 @@
+# Partner Launch Kit Source Notes
+
+A partner launch kit is the minimum viable asset bundle a partner needs to start sharing Moonshine Capital-powered resources without breaking attribution or creating compliance chaos.
+
+## Launch kit purpose
+
+The launch kit should help a partner answer:
+
+1. Who should I share this with?
+2. What link do I use?
+3. What do I say?
+4. What happens after someone clicks?
+5. How do I get credit?
+6. What should I avoid saying?
+
+## Recommended launch kit contents
+
+| Asset | Purpose |
+|---|---|
+| Partner profile link | Credible home base for warm referrals |
+| Primary funding-fit link | Main conversion path |
+| 3–5 resource cards | Curated tools/guides by audience |
+| Swipe copy | Email, DM, social, SMS, LinkedIn |
+| Partner FAQ | Explain process and expectations |
+| Intake expectations | Tell partners what prospects should prepare |
+| Protection rules | Prevent bad claims and attribution loss |
+| Follow-up notes | Explain what Moonshine handles after lead capture |
+
+## Minimum tracking setup
+
+Every launch kit should include a tracked version of each link using:
+
+```text
+partner_id
+campaign_id
+asset_id
+vertical
+product_intent
+page_type
+utm_source
+utm_medium
+utm_campaign
+```
+
+## Swipe copy structure
+
+Effective partner copy should include:
+
+1. Audience callout
+2. Pain point
+3. Useful asset
+4. Clear CTA
+5. No guarantee
+
+Example:
+
+```text
+If your business needs capital but you are not sure which route makes sense, start here. This Moonshine Capital-powered funding-fit tool helps point you toward the right next step based on your situation — not generic application roulette.
+```
+
+## Partner briefing script
+
+```text
+Your job is to share the right front-end asset with the right audience. Moonshine Capital handles tracking, intake, routing, fulfillment, and follow-up after the prospect clicks. Use the links we provide so attribution is preserved.
+```
+
+## What partners should know
+
+Partners should understand:
+
+- The link matters.
+- The first-click destination matters.
+- Tracking parameters protect attribution.
+- Public copy should stay simple.
+- Backend routing is not public-facing material.
+- Funding is never guaranteed.
+- Speed depends on fit, docs, and verification.
+
+## What partners should not need to know
+
+Partners do not need access to:
+
+- Private routing logic
+- Provider-specific fulfillment details
+- Backend partner portals
+- Internal CRM routing labels
+- Manual review rules
+- Private payout mechanics beyond their approved agreement
+
+## Launch kit checklist
+
+- [ ] Partner profile page created.
+- [ ] Partner ID assigned.
+- [ ] Primary tracked link generated.
+- [ ] Resource-card stack selected.
+- [ ] Swipe copy created.
+- [ ] Partner FAQ included.
+- [ ] Protection rules included.
+- [ ] Public copy reviewed.
+- [ ] Tracking tested.
+- [ ] CRM attribution fields mapped.
+
+## Quality rule
+
+A partner launch kit is not a random folder of links. It is a controlled referral system with training wheels, guardrails, and attribution baked in.

--- a/knowledge-base/partner-enablement/partner-lead-generation-strategy.md
+++ b/knowledge-base/partner-enablement/partner-lead-generation-strategy.md
@@ -1,0 +1,138 @@
+# Partner Lead Generation Strategy
+
+Moonshine Capital partners should be equipped to share useful front-end assets, not raw backend pages.
+
+The partner’s job is to create attention, trust, and intent. Moonshine Capital’s job is to capture, attribute, route, fulfill, and follow up.
+
+## Strategic model
+
+```text
+Partner audience + useful asset + tracked landing path + Moonshine routing = attributable lead flow
+```
+
+## Partner asset types
+
+| Asset type | Purpose | Best use |
+|---|---|---|
+| Broker profile page | Give partner a credible home base | Warm referrals, business cards, social bios |
+| Funding-fit landing page | Capture prospect intent | Direct response and outreach campaigns |
+| Calculator / tool | Create value before asking for info | Cold audiences, SEO, niche campaigns |
+| Vertical-specific page | Speak to a narrow audience | Truckers, contractors, ecommerce sellers, real estate investors |
+| Resource card stack | Curated partner toolkit | Broker profiles, onboarding hubs, training pages |
+| Email/DM swipe copy | Reduce partner friction | Launch kit and recurring campaigns |
+| Training article/video | Build partner competence | Agent onboarding and activation |
+
+## Front-end lead paths
+
+### 1. Broker profile path
+
+```text
+Partner shares profile URL
+→ prospect sees partner positioning and curated tools
+→ prospect clicks tracked resource or funding CTA
+→ lead capture occurs on Moonshine-controlled asset
+```
+
+Best for:
+
+- Existing referral relationships
+- Local brokers
+- Business cards
+- LinkedIn profiles
+- Warm intros
+
+### 2. Vertical campaign path
+
+```text
+Partner shares vertical-specific asset
+→ prospect lands on niche page or tool
+→ asset captures product intent and vertical
+→ Moonshine routes based on intake data
+```
+
+Best for:
+
+- Trucking
+- Contractors
+- Ecommerce sellers
+- Real estate investors
+- Startups
+- Self-employed/gig workers
+
+### 3. Tool-first path
+
+```text
+Partner shares calculator/tool
+→ prospect gets useful result
+→ lead capture is triggered before or after full result
+→ tool passes asset/product intent to routing layer
+```
+
+Best for:
+
+- Cold audiences
+- SEO content
+- YouTube descriptions
+- Social posts
+- Partner newsletters
+
+### 4. Education-first path
+
+```text
+Partner shares guide/article/video
+→ prospect learns funding-fit logic
+→ CTA points to tracked application, tool, or booking flow
+```
+
+Best for:
+
+- Longer sales cycles
+- High-trust partner audiences
+- LinkedIn/newsletter audiences
+- Professional referral partners
+
+## Lead generation principles
+
+1. **Lead with the prospect’s pain.** Do not lead with provider mechanics.
+2. **Use partner credibility.** The partner is the trust bridge, not the backend router.
+3. **Keep first-click destination controlled.** The first click should land on Moonshine-owned infrastructure.
+4. **Capture intent early.** Every link should preserve vertical, asset, partner, and product-intent context.
+5. **Make follow-up easier.** Every asset should give the CRM enough context for a relevant next action.
+
+## Suggested partner CTAs
+
+- Check your funding fit
+- See which funding path matches your business
+- Use this calculator before you apply
+- Start with the right capital lane
+- Get routed before you get rejected
+- Build your funding-readiness file
+- See if this tool fits your business situation
+
+## Avoid
+
+- Generic “apply now” links with no context.
+- Raw backend/provider pages as first-click destination.
+- Public copy naming backend providers.
+- Partner links with no attribution parameters.
+- Campaigns that send every prospect into the same intake flow.
+
+## Partner activation sequence
+
+1. Create partner profile or landing page.
+2. Assign partner tracking parameters.
+3. Give partner 3–5 assets matched to their audience.
+4. Provide swipe copy.
+5. Provide simple intake expectations.
+6. Review first leads manually for quality.
+7. Refine assets based on conversion and lead quality.
+
+## Measurement signals
+
+- Clicks by `partner_id`
+- Leads by `asset_id`
+- Conversion by `vertical`
+- Funding intent by `product_intent`
+- Page performance by `page_type`
+- Campaign performance by `utm_campaign`
+- Partner activity by campaign volume and lead quality

--- a/knowledge-base/partner-enablement/partner-link-tracking-model.md
+++ b/knowledge-base/partner-enablement/partner-link-tracking-model.md
@@ -1,0 +1,128 @@
+# Partner Link Tracking Model
+
+This model standardizes how partner links should be created, shared, captured, and routed.
+
+## Link objectives
+
+A good partner link should answer:
+
+1. Who sent the traffic?
+2. What asset did they share?
+3. Which campaign was it part of?
+4. What audience or vertical was targeted?
+5. What product intent did the prospect likely have?
+6. What page type received the traffic?
+7. Which marketing channel produced the click?
+
+## Required query parameters
+
+```text
+partner_id
+campaign_id
+asset_id
+vertical
+product_intent
+page_type
+utm_source
+utm_medium
+utm_campaign
+```
+
+## Example link
+
+```text
+https://www.distilledfunding.com/tools/trucker-repair-tracker?partner_id=darwin-hanneman&campaign_id=q2-trucking-repair&asset_id=trucker-repair-tracker&vertical=trucking&product_intent=working-capital&page_type=tool&utm_source=linkedin&utm_medium=social&utm_campaign=q2-trucking-repair
+```
+
+## Parameter definitions
+
+| Parameter | Required | Description | Example values |
+|---|---:|---|---|
+| `partner_id` | Yes | Partner or broker identifier | `darwin-hanneman`, `jason-feimster` |
+| `campaign_id` | Yes | Specific campaign or sequence | `q2-trucking-repair`, `startup-launch-kit` |
+| `asset_id` | Yes | Shared page/tool/resource identifier | `trucker-repair-tracker`, `funding-fit-guide` |
+| `vertical` | Yes | Target audience segment | `trucking`, `contractors`, `ecommerce`, `real-estate` |
+| `product_intent` | Yes | Inferred funding need | `working-capital`, `equipment-finance`, `line-of-credit` |
+| `page_type` | Yes | Destination type | `tool`, `broker-profile`, `landing-page`, `article` |
+| `utm_source` | Recommended | Channel/source | `linkedin`, `facebook`, `email`, `youtube` |
+| `utm_medium` | Recommended | Medium | `social`, `dm`, `newsletter`, `video-description` |
+| `utm_campaign` | Recommended | Campaign grouping | `q2-trucking-repair` |
+
+## Slug rules
+
+Use slugs that describe the public-facing asset.
+
+Good:
+
+```text
+/trucker-repair-tracker
+/business-funding-fit
+/broker/darwin-hanneman
+/tools/inventory-cash-flow
+```
+
+Avoid slugs that expose private partner mechanics, internal vendor labels, or non-public operational details.
+
+## Session persistence
+
+A front-end script or form embed should persist tracking values through:
+
+- Hidden form fields
+- Session storage
+- Local storage where appropriate
+- CRM custom properties
+- Webhook payloads
+
+## Hidden field model
+
+```json
+{
+  "partner_id": "",
+  "campaign_id": "",
+  "asset_id": "",
+  "vertical": "",
+  "product_intent": "",
+  "page_type": "",
+  "utm_source": "",
+  "utm_medium": "",
+  "utm_campaign": "",
+  "source_url": "",
+  "landing_page_url": ""
+}
+```
+
+## Redirect/tracking path model
+
+A `/go/[slug]` style redirect layer may be used for tracked outbound links.
+
+Recommended behavior:
+
+```text
+/go/[slug]
+→ capture click event
+→ preserve partner/session parameters
+→ redirect to a Moonshine-controlled destination or approved outbound asset
+```
+
+## Data quality rules
+
+- Use lowercase slugs.
+- Use hyphens, not spaces.
+- Do not include private provider names.
+- Do not duplicate partner IDs.
+- Do not rely only on UTMs for partner credit.
+- Preserve first-touch attribution when possible.
+- Store unknown values as `Unknown`, not blank, when data is expected but missing.
+
+## Review checklist
+
+Before giving a partner a link:
+
+- [ ] `partner_id` is present.
+- [ ] `asset_id` is present.
+- [ ] `campaign_id` is present.
+- [ ] `vertical` is present where relevant.
+- [ ] `product_intent` is present where relevant.
+- [ ] First-click destination is Moonshine-controlled.
+- [ ] Public slug avoids private operational details.
+- [ ] Hidden fields or CRM capture are configured.

--- a/knowledge-base/partner-enablement/partner-microsite-playbook.md
+++ b/knowledge-base/partner-enablement/partner-microsite-playbook.md
@@ -1,0 +1,131 @@
+# Partner Microsite Playbook
+
+Partner microsites give affiliates and referral partners a credible front-end presence without giving away backend routing, fulfillment, or attribution control.
+
+## Purpose
+
+A partner microsite should:
+
+- Position the partner credibly.
+- Explain who they help.
+- Provide curated funding/resource CTAs.
+- Capture attribution reliably.
+- Route traffic to Moonshine-controlled lead capture and tools.
+- Keep backend fulfillment white-labeled.
+
+## Recommended page types
+
+| Page type | Purpose | Example |
+|---|---|---|
+| Broker profile | Partner credibility page | `/broker/darwin-hanneman` |
+| Vertical landing page | Audience-specific offer | `/funding/trucking` |
+| Tool landing page | Lead magnet or calculator | `/tools/trucker-repair-tracker` |
+| Resource hub | Curated partner toolkit | `/partner-resources/[slug]` |
+| Application bridge | Funding-fit pre-intake | `/apply/fast` |
+
+## Microsite sections
+
+A strong partner microsite should include:
+
+1. Partner headline
+2. Who the partner helps
+3. Best-fit funding/resource lanes
+4. Curated resource cards
+5. Funding-fit CTA
+6. Document/readiness expectations
+7. Trust/disclaimer copy
+8. Tracking and attribution preservation
+
+## Partner profile content model
+
+```json
+{
+  "partner_id": "",
+  "slug": "",
+  "display_name": "",
+  "headline": "",
+  "audience": [],
+  "specialties": [],
+  "featured_resources": [],
+  "primary_cta_url": "",
+  "booking_url": "",
+  "is_active": true
+}
+```
+
+## Resource card stack
+
+Each profile should include 3–6 cards matched to the partner’s audience.
+
+Examples:
+
+- Funding-fit tool
+- Industry-specific calculator
+- Business credit readiness guide
+- Application/start-here page
+- Booking link
+- Training or explainer article
+
+## CTA hierarchy
+
+Primary CTA:
+
+```text
+Check funding fit
+```
+
+Secondary CTAs:
+
+```text
+Use this calculator
+Book a strategy call
+View readiness checklist
+Start application
+```
+
+## First-click rule
+
+The first click from partner traffic should land on a Moonshine-controlled page, tool, or profile.
+
+This protects:
+
+- Attribution
+- Follow-up
+- Lead capture
+- Routing quality
+- White-label consistency
+- Partner credit
+
+## Microsite launch checklist
+
+- [ ] Partner slug created.
+- [ ] `partner_id` assigned.
+- [ ] Profile copy approved.
+- [ ] Featured resources selected.
+- [ ] Primary CTA includes tracking parameters.
+- [ ] Tool/resource clicks preserve attribution.
+- [ ] No private provider names in public copy.
+- [ ] No raw outbound first-click links.
+- [ ] Disclaimer language included.
+- [ ] Mobile layout checked.
+
+## Public-safe profile copy pattern
+
+```text
+[Partner Name] helps [audience] understand practical funding paths for [use case]. This page includes curated tools and resources powered by Moonshine Capital to help prospects start with the right next step.
+```
+
+## Internal-only notes
+
+Keep these out of public profile copy:
+
+- Commission structure
+- Backend fulfillment route
+- Private partner notes
+- Provider-specific rules
+- Manual override logic
+- Internal CRM labels
+
+## Guardrail
+
+A microsite is not a fake bank branch. It is a partner-branded front door into a Moonshine-controlled routing system.

--- a/knowledge-base/partner-enablement/partner-routing-attribution-spec.md
+++ b/knowledge-base/partner-enablement/partner-routing-attribution-spec.md
@@ -1,0 +1,125 @@
+# Partner Routing + Attribution Spec
+
+This spec defines how Moonshine Capital should preserve partner attribution while keeping lead capture, routing, fulfillment, and follow-up under Moonshine-controlled infrastructure.
+
+## Core ownership model
+
+| Layer | Owner | Notes |
+|---|---|---|
+| Audience relationship | Partner | Partner introduces or promotes the asset |
+| First-click destination | Moonshine Capital | Must be controlled and trackable |
+| Attribution capture | Moonshine Capital | Query params, hidden fields, CRM fields |
+| Intake and lead capture | Moonshine Capital | Forms, tools, portals, booking flows |
+| Routing logic | Moonshine Capital | Product intent, vertical, readiness, docs |
+| Backend fulfillment | Moonshine Capital | White-labeled; backend providers not exposed publicly |
+| Follow-up | Moonshine Capital | CRM tasks, nurture, document rescue, status updates |
+
+## Required tracking parameters
+
+Every partner-facing link should support these parameters:
+
+| Parameter | Purpose | Example |
+|---|---|---|
+| `partner_id` | Identifies partner/referrer | `darwin-hanneman` |
+| `campaign_id` | Identifies campaign or push | `trucking-q2-launch` |
+| `asset_id` | Identifies shared asset/tool/page | `repair-revenue-tracker` |
+| `vertical` | Identifies audience segment | `trucking` |
+| `product_intent` | Captures likely funding need | `equipment-finance` |
+| `page_type` | Identifies destination format | `broker-profile`, `tool`, `landing-page` |
+| `utm_source` | Standard source tracking | `linkedin`, `facebook`, `email` |
+| `utm_medium` | Standard medium tracking | `social`, `dm`, `newsletter` |
+| `utm_campaign` | Standard campaign tracking | `truck-repair-q2` |
+
+## Canonical URL pattern
+
+```text
+https://moonshine-controlled-domain.com/[page-path]?partner_id=[partner]&campaign_id=[campaign]&asset_id=[asset]&vertical=[vertical]&product_intent=[intent]&page_type=[type]&utm_source=[source]&utm_medium=[medium]&utm_campaign=[campaign]
+```
+
+## Minimum persisted fields
+
+Lead capture systems should preserve:
+
+```json
+{
+  "partner_id": "",
+  "campaign_id": "",
+  "asset_id": "",
+  "vertical": "",
+  "product_intent": "",
+  "page_type": "",
+  "utm_source": "",
+  "utm_medium": "",
+  "utm_campaign": "",
+  "landing_page_url": "",
+  "referrer_url": "",
+  "created_at": "",
+  "lead_status": "new"
+}
+```
+
+## Routing logic
+
+```text
+IF product_intent is present → use as first routing clue
+ELSE IF asset_id maps to a product family → infer product intent from asset
+ELSE IF vertical is present → route to vertical intake or general funding triage
+ELSE → route to general funding intake
+```
+
+## Attribution hierarchy
+
+When multiple values conflict, use this hierarchy:
+
+1. Explicit hidden form fields from URL params
+2. Stored session attribution
+3. First-party cookie/local storage attribution
+4. Referrer URL
+5. Partner profile slug/path
+6. Manual CRM correction
+7. Unknown
+
+## Multi-touch rule
+
+Default first-touch attribution should be preserved for partner protection.
+
+Last-touch data can also be stored for campaign optimization.
+
+Recommended fields:
+
+```text
+first_partner_id
+last_partner_id
+first_asset_id
+last_asset_id
+first_utm_campaign
+last_utm_campaign
+```
+
+## Partner-safe routing principle
+
+Partners should not need to understand backend routing to get credit.
+
+They share the front-end asset; Moonshine Capital captures the attribution and routes the lead internally.
+
+## CRM notes format
+
+```text
+Partner attribution: [partner_id]
+Campaign: [campaign_id]
+Asset: [asset_id]
+Vertical: [vertical]
+Product intent: [product_intent]
+Page type: [page_type]
+UTM source/medium/campaign: [utm_source] / [utm_medium] / [utm_campaign]
+Routing note: [inferred route]
+Next action: [application/docs/booking/manual review]
+```
+
+## Guardrails
+
+- Do not expose provider names in public metadata.
+- Do not put backend provider names in slugs.
+- Do not send partner traffic directly to raw backend pages.
+- Do not rely on manual attribution when URL/session capture is available.
+- Do not overwrite first-touch partner credit without a defined business rule.


### PR DESCRIPTION
Fixes #6.

## Summary

Adds the Moonshine Capital partner enablement knowledge base covering lead generation strategy, routing and attribution, partner link tracking, microsites, affiliate protection, launch kits, and broker profile resource card rules.

## Files added

- `knowledge-base/partner-enablement/README.md`
- `knowledge-base/partner-enablement/partner-lead-generation-strategy.md`
- `knowledge-base/partner-enablement/partner-routing-attribution-spec.md`
- `knowledge-base/partner-enablement/partner-link-tracking-model.md`
- `knowledge-base/partner-enablement/partner-microsite-playbook.md`
- `knowledge-base/partner-enablement/affiliate-protection-rules.md`
- `knowledge-base/partner-enablement/partner-launch-kit-source-notes.md`
- `knowledge-base/partner-enablement/broker-profile-resource-card-rules.md`

## Validation checklist

- [x] Scope matches Issue #6.
- [x] Includes required tracking parameters: `partner_id`, `campaign_id`, `asset_id`, `vertical`, `product_intent`, `page_type`, `utm_source`, `utm_medium`, `utm_campaign`.
- [x] Emphasizes that partners share front-end assets while Moonshine Capital owns attribution, lead capture, routing, backend fulfillment, and follow-up.
- [x] Includes affiliate protection rules.
- [x] Keeps public language white-labeled and controlled.
- [x] Does not expose backend providers publicly.
- [x] Does not begin Issue #7 or later.

## Stop condition

PR opened into `main`; no further issue work started.