### PR TITLE
Add utility workbench for agents and skills

### DIFF
--- a/agent-catalog.html
+++ b/agent-catalog.html
@@ -4,11 +4,12 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Agent Catalog | AI Agent Library</title>
-  <meta name="description" content="Browse productized AI agents by category, buyer, pain solved, platform, status, priority, and tags.">
+  <meta name="description" content="Browse productized AI agents and open each one in the Agent Workbench to generate platform-ready build assets.">
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>
+
   <header class="site-header">
     <div class="nav-wrap">
       <a class="brand" href="index.html"><span class="brand-mark">AI</span><span>Agent Library</span></a>
@@ -25,26 +26,53 @@
       </nav>
     </div>
   </header>
+
   <section class="hero">
     <div class="eyebrow">Agent Directory</div>
     <h1>Agent Catalog</h1>
-    <p>Browse productized AI agents by category, buyer, pain solved, platform, status, priority, and tags.</p>
+    <p>Browse productized AI agents, then open one in the workbench to generate Custom GPT instructions, Gemini Gem starters, Notion specs, Vercel page briefs, and GitHub issue prompts.</p>
   </section>
+
   <main id="main">
+    <section class="section callout">
+      <strong>Catalog rule:</strong>
+      <p>The catalog is for choosing an agent. The workbench is for building with it. Source Markdown is now secondary, because nobody came here to admire files in a glass coffin.</p>
+    </section>
+
     <section class="section">
       <div class="toolbar">
-        <input id="searchInput" type="search" placeholder="Search agents...">
+        <input id="searchInput" type="search" placeholder="Search agents, buyers, pains, tags...">
         <select id="categoryFilter"><option value="all">All categories</option></select>
-        <select id="sortSelect"><option value="priority">Sort by priority</option><option value="name">Sort by name</option><option value="category">Sort by category</option></select>
+        <select id="sortSelect">
+          <option value="priority">Sort by priority</option>
+          <option value="name">Sort by name</option>
+          <option value="category">Sort by category</option>
+        </select>
       </div>
     </section>
+
     <section class="section"><div id="stats" class="stat-row"></div></section>
     <section class="section"><div id="grid" class="wide-grid"></div></section>
+
     <section class="section two-col">
-      <article class="card"><h2>Agent card standard</h2><ul class="mini-list"><li>Name and category.</li><li>Buyer and pain solved.</li><li>Platform target and priority.</li><li>Source file path and tags.</li></ul></article>
-      <article class="card"><h2>Next build path</h2><p>Use the agent schema and knowledge-base folders to turn high-priority draft agents into per-agent Markdown specs.</p><a class="button-link" href="schemas/agent.schema.json">Open agent schema →</a></article>
+      <article class="card">
+        <h2>Useful agent card standard</h2>
+        <ul class="mini-list">
+          <li>Primary action: open workbench.</li>
+          <li>Secondary action: open source file.</li>
+          <li>Show buyer, pain solved, platform target, and monetization.</li>
+          <li>Make the next build path obvious.</li>
+        </ul>
+      </article>
+
+      <article class="card">
+        <h2>Next build path</h2>
+        <p>Use the workbench output to create Custom GPTs, Gemini Gems, Notion pages, Vercel pages, or GitHub implementation issues.</p>
+        <a class="button-link" href="agent-workbench.html">Open Agent Workbench →</a>
+      </article>
     </section>
   </main>
+
   <footer class="footer">
     <p><strong>AI Agent Library</strong> — reusable agents, skills, prompt systems, knowledge bases, platform packs, and deployable AI product assets.</p>
     <p>
@@ -56,6 +84,7 @@
     </p>
     <p>© <span data-year></span> AI Agent Library.</p>
   </footer>
+
   <script src="script.js"></script>
   <script>
     (async () => {
@@ -66,20 +95,74 @@
       const sortSelect = document.getElementById("sortSelect");
       const stats = document.getElementById("stats");
       const grid = document.getElementById("grid");
-      AILibrary.unique(agents.map(a => a.category)).forEach(category => categorySelect.insertAdjacentHTML("beforeend", `<option value="${AILibrary.escapeHTML(category)}">${AILibrary.escapeHTML(category)}</option>`));
-      function weight(priority) { return { High: 1, high: 1, Medium: 2, medium: 2, Low: 3, low: 3 }[priority] || 9; }
+
+      AILibrary.unique(agents.map((agent) => agent.category)).forEach((category) => {
+        categorySelect.insertAdjacentHTML("beforeend", `<option value="${AILibrary.escapeHTML(category)}">${AILibrary.escapeHTML(category)}</option>`);
+      });
+
       function render() {
         const q = searchInput.value.toLowerCase();
         const cat = categorySelect.value;
         const sort = sortSelect.value;
-        let visible = agents.filter(a => [a.name, a.category, a.buyer, a.pain_solved, a.platform, a.status, (a.tags || []).join(" ")].join(" ").toLowerCase().includes(q) && (cat === "all" || a.category === cat));
-        if (sort === "name") visible.sort((a,b) => a.name.localeCompare(b.name));
-        if (sort === "category") visible.sort((a,b) => `${a.category}${a.name}`.localeCompare(`${b.category}${b.name}`));
-        if (sort === "priority") visible.sort((a,b) => weight(a.priority) - weight(b.priority));
-        stats.innerHTML = `<div class="stat"><strong>${agents.length}</strong><span>Total agents</span></div><div class="stat"><strong>${AILibrary.unique(agents.map(a => a.category)).length}</strong><span>Categories</span></div><div class="stat"><strong>${visible.length}</strong><span>Visible results</span></div>`;
-        grid.innerHTML = visible.map(a => `<article class="card"><div class="pill-row"><span class="pill gold">${AILibrary.escapeHTML(a.category)}</span><span class="pill">${AILibrary.escapeHTML(a.priority)}</span><span class="pill">${AILibrary.escapeHTML(a.status)}</span></div><h2>${AILibrary.escapeHTML(a.name)}</h2><p><strong>Buyer:</strong> ${AILibrary.escapeHTML(a.buyer)}</p><p>${AILibrary.escapeHTML(a.pain_solved)}</p><p><strong>Platform:</strong> ${AILibrary.escapeHTML(a.platform)}</p><div class="pill-row">${(a.tags || []).map(t => `<span class="pill">${AILibrary.escapeHTML(t)}</span>`).join("")}</div>${a.file ? `<a class="button-link secondary" href="${AILibrary.escapeHTML(a.file)}">Open source file →</a>` : `<a class="button-link secondary" href="contribute.html">Create source file →</a>`}</article>`).join("") || `<div class="empty-state">No matching agents.</div>`;
+
+        let visible = agents.filter((agent) => {
+          const searchable = [
+            agent.name,
+            agent.category,
+            agent.buyer,
+            agent.pain_solved,
+            agent.platform,
+            agent.status,
+            agent.priority,
+            agent.monetization,
+            (agent.tags || []).join(" ")
+          ].join(" ").toLowerCase();
+
+          return searchable.includes(q) && (cat === "all" || agent.category === cat);
+        });
+
+        if (sort === "name") visible.sort((a, b) => a.name.localeCompare(b.name));
+        if (sort === "category") visible.sort((a, b) => `${a.category}${a.name}`.localeCompare(`${b.category}${b.name}`));
+        if (sort === "priority") visible.sort((a, b) => AILibrary.priorityWeight(a.priority) - AILibrary.priorityWeight(b.priority));
+
+        stats.innerHTML = `
+          <div class="stat"><strong>${agents.length}</strong><span>Total agents</span></div>
+          <div class="stat"><strong>${AILibrary.unique(agents.map((agent) => agent.category)).length}</strong><span>Categories</span></div>
+          <div class="stat"><strong>${visible.length}</strong><span>Visible results</span></div>
+        `;
+
+        grid.innerHTML = visible.map((agent) => {
+          const workbenchUrl = `agent-workbench.html?agent=${encodeURIComponent(agent.slug)}`;
+
+          return `
+            <article class="card">
+              <div class="pill-row">
+                <span class="pill gold">${AILibrary.escapeHTML(agent.category)}</span>
+                <span class="pill">${AILibrary.escapeHTML(agent.priority)}</span>
+                <span class="pill">${AILibrary.escapeHTML(agent.status)}</span>
+              </div>
+              <h2>${AILibrary.escapeHTML(agent.name)}</h2>
+              <p><strong>Buyer:</strong> ${AILibrary.escapeHTML(agent.buyer)}</p>
+              <p>${AILibrary.escapeHTML(agent.pain_solved)}</p>
+              <p><strong>Monetization:</strong> ${AILibrary.escapeHTML(agent.monetization)}</p>
+              <p><strong>Platform:</strong> ${AILibrary.escapeHTML(agent.platform)}</p>
+              <div class="pill-row">
+                ${(agent.tags || []).map((tag) => `<span class="pill">${AILibrary.escapeHTML(tag)}</span>`).join("")}
+              </div>
+              <div class="pill-row">
+                <a class="button-link" href="${workbenchUrl}">Open workbench →</a>
+                ${agent.file ? `<a class="button-link secondary" href="${AILibrary.escapeHTML(agent.file)}">Source file →</a>` : `<a class="button-link secondary" href="contribute.html">Create source →</a>`}
+              </div>
+            </article>
+          `;
+        }).join("") || `<div class="empty-state">No matching agents.</div>`;
       }
-      [searchInput, categorySelect, sortSelect].forEach(el => { el.addEventListener("input", render); el.addEventListener("change", render); });
+
+      [searchInput, categorySelect, sortSelect].forEach((el) => {
+        el.addEventListener("input", render);
+        el.addEventListener("change", render);
+      });
+
       render();
     })();
   </script>

--- a/agent-workbench.html
+++ b/agent-workbench.html
@@ -1,0 +1,382 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Agent Workbench | AI Agent Library</title>
+  <meta name="description" content="Turn an AI Agent Library record into copyable build assets for Custom GPTs, Gemini Gems, Notion pages, GitHub issues, and static Vercel pages.">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+
+  <header class="site-header">
+    <div class="nav-wrap">
+      <a class="brand" href="index.html"><span class="brand-mark">AI</span><span>Agent Library</span></a>
+      <nav class="nav-links" aria-label="Primary navigation">
+        <a href="index.html">Home</a>
+        <a href="agent-catalog.html" aria-current="page">Agents</a>
+        <a href="skill-catalog.html">Skills</a>
+        <a href="categories.html">Categories</a>
+        <a href="platforms.html">Platforms</a>
+        <a href="knowledge-bases.html">Knowledge</a>
+        <a href="portfolio.html">Portfolio</a>
+        <a href="roadmap.html">Roadmap</a>
+        <a href="search.html">Search</a>
+      </nav>
+    </div>
+  </header>
+
+  <section class="hero">
+    <div class="eyebrow">Build Console</div>
+    <h1>Agent Workbench</h1>
+    <p>Pick an agent and generate useful implementation assets instead of opening another raw Markdown file like a raccoon reading tax code.</p>
+  </section>
+
+  <main id="main">
+    <section class="section card">
+      <h2>Choose an agent</h2>
+      <p>Select a library record and generate copy-ready build material for the platform you actually want to use.</p>
+      <div class="form-grid">
+        <label>
+          Agent
+          <select id="agentSelect"></select>
+        </label>
+        <label>
+          Target platform
+          <select id="platformSelect">
+            <option value="custom-gpt">Custom GPT</option>
+            <option value="gemini-gem">Gemini Gem</option>
+            <option value="notion">Notion operating page</option>
+            <option value="vercel">Static Vercel page</option>
+            <option value="github-issue">GitHub implementation issue</option>
+          </select>
+        </label>
+        <label>
+          Build depth
+          <select id="depthSelect">
+            <option value="starter">Starter</option>
+            <option value="operator">Operator-ready</option>
+            <option value="repo">Repo-ready</option>
+          </select>
+        </label>
+      </div>
+      <div class="pill-row">
+        <button id="buildAsset" class="button">Generate build asset</button>
+        <button id="copyAsset" class="button secondary">Copy output</button>
+        <a id="sourceLink" class="button-link secondary" href="agent-catalog.html">Open source file →</a>
+      </div>
+    </section>
+
+    <section class="section two-col">
+      <article class="card" id="agentOverview">
+        <h2>Agent overview</h2>
+        <p>Loading agent...</p>
+      </article>
+
+      <article class="card">
+        <h2>What this workbench produces</h2>
+        <ul class="mini-list">
+          <li>Role/instruction starter for assistant platforms.</li>
+          <li>Inputs, outputs, workflow, and review gates.</li>
+          <li>Knowledge-base and skill dependency checklist.</li>
+          <li>Static page or Notion implementation brief.</li>
+          <li>GitHub issue prompt for repo execution.</li>
+        </ul>
+      </article>
+    </section>
+
+    <section class="section card">
+      <h2>Generated build asset</h2>
+      <pre id="output">Choose an agent, select a target platform, then generate a build asset.</pre>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <p><strong>AI Agent Library</strong> — reusable agents, skills, prompt systems, knowledge bases, platform packs, and deployable AI product assets.</p>
+    <p>
+      <a href="terms.html">Terms</a> ·
+      <a href="privacy.html">Privacy</a> ·
+      <a href="data-policy.html">Data Policy</a> ·
+      <a href="affiliate-disclosure.html">Affiliate Disclosure</a> ·
+      <a href="contribute.html">Contribute</a>
+    </p>
+    <p>© <span data-year></span> AI Agent Library.</p>
+  </footer>
+
+  <script src="script.js"></script>
+  <script>
+    (async () => {
+      const rawAgents = await AILibrary.fetchJSON(["agent-index.json", "site-data/agents.fallback.json"], []);
+      const rawSkills = await AILibrary.fetchJSON(["skills/skill-index.json", "site-data/skills.fallback.json"], []);
+      const agents = rawAgents.map(AILibrary.normalizeAgent);
+      const skills = rawSkills.map(AILibrary.normalizeSkill);
+
+      const agentSelect = document.getElementById("agentSelect");
+      const platformSelect = document.getElementById("platformSelect");
+      const depthSelect = document.getElementById("depthSelect");
+      const overview = document.getElementById("agentOverview");
+      const output = document.getElementById("output");
+      const sourceLink = document.getElementById("sourceLink");
+      const buildButton = document.getElementById("buildAsset");
+      const copyButton = document.getElementById("copyAsset");
+
+      function findAgent() {
+        return agents.find((agent) => agent.slug === agentSelect.value) || agents[0];
+      }
+
+      function relatedSkills(agent) {
+        const haystack = `${agent.name} ${agent.slug} ${agent.category} ${agent.pain_solved}`.toLowerCase();
+        const category = agent.category.toLowerCase();
+        return skills.filter((skill) => {
+          const skillText = `${skill.name} ${skill.slug} ${skill.category} ${skill.problem_solved}`.toLowerCase();
+          return skillText.includes(category.split(" ")[0]) || haystack.includes(skill.category.toLowerCase().split(" ")[0]);
+        }).slice(0, 4);
+      }
+
+      function renderOverview() {
+        const agent = findAgent();
+        const matches = relatedSkills(agent);
+        sourceLink.href = agent.file || "agent-catalog.html";
+
+        overview.innerHTML = `
+          <h2>${AILibrary.escapeHTML(agent.name)}</h2>
+          <div class="pill-row">
+            <span class="pill gold">${AILibrary.escapeHTML(agent.category)}</span>
+            <span class="pill">${AILibrary.escapeHTML(agent.priority)}</span>
+            <span class="pill">${AILibrary.escapeHTML(agent.status)}</span>
+          </div>
+          <p><strong>Buyer:</strong> ${AILibrary.escapeHTML(agent.buyer)}</p>
+          <p><strong>Pain solved:</strong> ${AILibrary.escapeHTML(agent.pain_solved)}</p>
+          <p><strong>Monetization:</strong> ${AILibrary.escapeHTML(agent.monetization)}</p>
+          <h3>Likely skill dependencies</h3>
+          <div class="pill-row">
+            ${matches.map((skill) => `<a class="pill" href="skill-builder.html?skill=${AILibrary.escapeHTML(skill.slug)}">${AILibrary.escapeHTML(skill.name)}</a>`).join("") || `<span class="pill">Skill match TBD</span>`}
+          </div>
+        `;
+      }
+
+      function buildCustomGpt(agent, depth) {
+        const matches = relatedSkills(agent);
+        return `# Custom GPT Starter: ${agent.name}
+
+## Role
+You are ${agent.name}, a focused AI assistant for ${agent.buyer}.
+
+## Job To Be Done
+Help the operator solve this problem:
+${agent.pain_solved}
+
+## Primary User
+${agent.buyer}
+
+## Operating Mode
+- Ask for missing context before generating final outputs.
+- Convert messy input into structured, reviewable next steps.
+- Prefer practical checklists, drafts, routing logic, and reusable templates.
+- Keep outputs public-safe unless the user explicitly marks the workflow internal.
+
+## Core Workflow
+1. Identify the user's goal and current stage.
+2. Collect required inputs, constraints, and source material.
+3. Diagnose gaps, blockers, or routing issues.
+4. Generate the requested output in a copy-ready format.
+5. Add review notes, assumptions, and next actions.
+
+## Recommended Skills
+${AILibrary.listLines(matches.map((skill) => `${skill.name} — ${skill.path}`), "- No direct skill match yet. Use the Skill Catalog to add one.")}
+
+## Guardrails
+- Do not invent facts, approvals, funding outcomes, revenue outcomes, legal conclusions, tax advice, or private data.
+- Do not expose backend providers, private affiliate routing, or sensitive partner logic in public outputs.
+- Use educational, readiness, possible-fit, review-required, and next-step language.
+
+## Starter Conversation Prompts
+- "Use this agent to analyze the following situation and produce the next best action plan."
+- "Turn this messy source material into a structured workflow, checklist, and output template."
+- "Create a public-safe version and an internal operator version of this asset."
+
+## Build Depth
+${depth}
+`;
+      }
+
+      function buildGem(agent, depth) {
+        return `# Gemini Gem Starter: ${agent.name}
+
+## Gem Purpose
+Package ${agent.name} as a lightweight reusable assistant for ${agent.buyer}.
+
+## What The Gem Helps With
+${agent.pain_solved}
+
+## Instructions
+- Start by asking what asset, workflow, or decision the user needs.
+- Keep answers structured with sections, checklists, and copyable drafts.
+- Offer a practical next step instead of generic education.
+- Flag missing information before making assumptions.
+
+## Output Formats
+- Intake checklist
+- Recommended next action
+- Draft message or script
+- Workflow outline
+- Implementation notes
+
+## Safety Rules
+- No guaranteed results.
+- No invented claims or private data.
+- No backend-provider exposure in public-facing material.
+
+## Build Depth
+${depth}
+`;
+      }
+
+      function buildNotion(agent, depth) {
+        return `# Notion Operating Page Spec: ${agent.name}
+
+## Page Title
+${agent.name}
+
+## Purpose
+Create a Notion operating page that turns this agent into a repeatable workflow for ${agent.buyer}.
+
+## Suggested Sections
+1. Overview
+2. Intake Questions
+3. Required Inputs
+4. Workflow Steps
+5. Output Templates
+6. Review Checklist
+7. Related Skills
+8. Related Knowledge Bases
+9. Launch / Maintenance Notes
+
+## Database Properties
+- Name: title
+- Category: select — ${agent.category}
+- Buyer: text
+- Pain Solved: text
+- Status: select — Draft, Ready, Live, Retired
+- Priority: select — High, Medium, Low
+- Platform Target: multi-select — Custom GPT, Gemini Gem, Vercel, Notion, GitHub
+- Source File: url/text — ${agent.file || "TBD"}
+- Last Reviewed: date
+
+## Related Skills
+${AILibrary.listLines(relatedSkills(agent).map((skill) => skill.name))}
+
+## Build Depth
+${depth}
+`;
+      }
+
+      function buildVercel(agent, depth) {
+        return `# Static Vercel Page Brief: ${agent.name}
+
+## Page Goal
+Create a dependency-free static landing/detail page that explains what ${agent.name} does and gives the operator a clear next action.
+
+## Recommended Route
+/agents/${agent.slug}.html
+
+## Hero
+Headline: ${agent.name}
+Subheadline: ${agent.pain_solved}
+Audience: ${agent.buyer}
+
+## Page Sections
+1. What this agent does
+2. Who it is for
+3. Inputs needed
+4. Outputs produced
+5. Recommended skills
+6. Platform packaging options
+7. Public-safe guardrails
+8. Build / copy / deploy CTA
+
+## CTA Options
+- Generate Custom GPT instructions
+- Build Notion operating page
+- Create GitHub implementation issue
+- Open source spec
+
+## Source File
+${agent.file || "TBD"}
+
+## Build Depth
+${depth}
+`;
+      }
+
+      function buildIssue(agent, depth) {
+        return `# GitHub Issue Prompt: Implement ${agent.name} Utility Page
+
+## Goal
+Turn ${agent.name} from a static catalog entry into a useful build asset.
+
+## Scope
+- Create or improve an agent detail/workbench page for ${agent.slug}.
+- Use the existing agent-index.json record as source of truth.
+- Show buyer, pain solved, monetization, source path, and recommended platform options.
+- Add copyable output blocks for Custom GPT, Gemini Gem, Notion, Vercel, and implementation prompts.
+
+## Source Record
+- Name: ${agent.name}
+- Category: ${agent.category}
+- Buyer: ${agent.buyer}
+- Pain solved: ${agent.pain_solved}
+- Source file: ${agent.file || "TBD"}
+
+## Acceptance Criteria
+- The user can do something useful without opening raw Markdown.
+- CTAs do not loop back to the same page without explanation.
+- Any source-file link is secondary, not the main value proposition.
+- No private data, API keys, unsupported claims, or backend-provider bypass paths.
+- Static HTML/CSS/JS only.
+
+## Build Depth
+${depth}
+`;
+      }
+
+      function buildAsset() {
+        const agent = findAgent();
+        const target = platformSelect.value;
+        const depth = depthSelect.value;
+        const builders = {
+          "custom-gpt": buildCustomGpt,
+          "gemini-gem": buildGem,
+          notion: buildNotion,
+          vercel: buildVercel,
+          "github-issue": buildIssue
+        };
+
+        output.textContent = builders[target](agent, depth);
+      }
+
+      agents.forEach((agent) => {
+        agentSelect.insertAdjacentHTML("beforeend", `<option value="${AILibrary.escapeHTML(agent.slug)}">${AILibrary.escapeHTML(agent.name)}</option>`);
+      });
+
+      const requestedAgent = AILibrary.queryParam("agent");
+      if (requestedAgent && agents.some((agent) => agent.slug === requestedAgent)) {
+        agentSelect.value = requestedAgent;
+      }
+
+      agentSelect.addEventListener("change", () => {
+        renderOverview();
+        buildAsset();
+      });
+      platformSelect.addEventListener("change", buildAsset);
+      depthSelect.addEventListener("change", buildAsset);
+      buildButton.addEventListener("click", buildAsset);
+      copyButton.addEventListener("click", () => AILibrary.copyText(output.textContent, copyButton));
+
+      renderOverview();
+      buildAsset();
+    })();
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>AI Agent Library | AI Agent Library</title>
-  <meta name="description" content="A static-first library for reusable AI agents, skills, prompt systems, knowledge bases, schemas, examples, platform packs, and deployable AI product assets.">
+  <title>AI Agent Library | Build Console</title>
+  <meta name="description" content="A static-first build console for turning reusable AI agent and skill records into Custom GPT instructions, Gemini Gems, Notion specs, Vercel briefs, and GitHub implementation prompts.">
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
@@ -25,37 +25,46 @@
       </nav>
     </div>
   </header>
+
   <section class="hero">
-    <div class="eyebrow">Static AI Operating System</div>
-    <h1>Build, browse, and package reusable AI agents.</h1>
-    <p>A static-first library for reusable AI agents, skills, prompt systems, knowledge bases, schemas, examples, platform packs, and deployable AI product assets.</p>
+    <div class="eyebrow">Static AI Build Console</div>
+    <h1>Turn agent ideas into deployable AI assets.</h1>
+    <p>Browse reusable agents and skills, then generate platform-ready build material for Custom GPTs, Gemini Gems, Notion systems, static Vercel pages, and GitHub implementation issues.</p>
+    <div class="pill-row">
+      <a class="button-link" href="agent-workbench.html">Open Agent Workbench →</a>
+      <a class="button-link secondary" href="skill-catalog.html">Browse Skills →</a>
+    </div>
   </section>
+
   <main id="main">
     <section class="section callout">
       <strong>Operator note:</strong>
-      <p>This site is designed as a dependency-free static resource hub. Use it to browse agents, skills, schemas, knowledge bases, examples, platform packs, partner resources, and deployment portfolios.</p>
+      <p>This site is being shifted from a static display library into a working build console. Catalogs help you choose. Workbench pages help you build.</p>
     </section>
 
     <section class="section">
       <div class="grid">
         <article class="card">
-          <div class="pill-row"><span class="pill gold">Agents</span><span class="pill">Directory</span></div>
-          <h2>Agent Catalog</h2>
-          <p>Browse productized AI agents by category, buyer, pain solved, platform, priority, and status.</p>
-          <a class="button-link" href="agent-catalog.html">Browse agents →</a>
+          <div class="pill-row"><span class="pill gold">Agents</span><span class="pill">Build Console</span></div>
+          <h2>Agent Workbench</h2>
+          <p>Pick an agent and generate copy-ready Custom GPT instructions, Gemini Gem starters, Notion specs, Vercel page briefs, and GitHub issue prompts.</p>
+          <a class="button-link" href="agent-workbench.html">Build from an agent →</a>
         </article>
+
         <article class="card">
           <div class="pill-row"><span class="pill blue">Skills</span><span class="pill">Reusable Capabilities</span></div>
           <h2>Skill Catalog</h2>
-          <p>Browse reusable skills that can power multiple agents, workflows, static pages, and platform packs.</p>
+          <p>Browse reusable skills and open each one in a prefilled SKILL.md builder instead of staring at a generic form.</p>
           <a class="button-link" href="skill-catalog.html">Browse skills →</a>
         </article>
+
         <article class="card">
           <div class="pill-row"><span class="pill purple">Knowledge</span><span class="pill">Source Layer</span></div>
           <h2>Knowledge Bases</h2>
           <p>Open source folders for funding, partner enablement, CRM, content ops, automation, local referrals, and engineering-as-marketing.</p>
           <a class="button-link" href="knowledge-bases.html">Open knowledge bases →</a>
         </article>
+
         <article class="card">
           <div class="pill-row"><span class="pill green">Platforms</span><span class="pill">Packaging</span></div>
           <h2>Platform Hub</h2>
@@ -67,24 +76,24 @@
 
     <section class="section two-col">
       <article class="card">
-        <h2>What this repo organizes</h2>
+        <h2>What this library should do</h2>
         <ul class="mini-list">
-          <li>Agent specs and canonical agent indexes.</li>
-          <li>Skill specs and SKILL.md-ready playbooks.</li>
-          <li>Prompt chains, templates, schemas, and examples.</li>
-          <li>Knowledge-base folders and public-safe source rules.</li>
-          <li>Vercel, Custom GPT, Gemini Gem, and Flash UI portfolio records.</li>
-          <li>Affiliate, partner, and local referral enablement assets.</li>
+          <li>Help choose the right agent or skill for a job.</li>
+          <li>Generate copyable platform starter assets.</li>
+          <li>Connect agents to skills, knowledge bases, templates, and platform packs.</li>
+          <li>Turn repo records into deployable operating assets.</li>
+          <li>Keep static-first deployment simple: HTML, CSS, JS, JSON, Markdown.</li>
         </ul>
       </article>
+
       <article class="card">
         <h2>Static-first rule</h2>
         <p>Default implementation stays boring on purpose: HTML, CSS, JavaScript, JSON, and Markdown. No framework tax. No build goblin. No dependency swamp.</p>
         <div class="pill-row">
-          <a class="pill gold" href="featured.html">Featured</a>
-          <a class="pill gold" href="new.html">New</a>
+          <a class="pill gold" href="agent-catalog.html">Agents</a>
+          <a class="pill gold" href="agent-workbench.html">Workbench</a>
+          <a class="pill gold" href="skill-builder.html">Skill Builder</a>
           <a class="pill gold" href="search.html">Search</a>
-          <a class="pill gold" href="contribute.html">Contribute</a>
         </div>
       </article>
     </section>
@@ -94,6 +103,7 @@
       <p>Funding, credit, affiliate, partner, platform, automation, and business-outcome pages must avoid guaranteed approvals, funding, credit outcomes, revenue, rankings, and fake social proof. Use educational, readiness, review-required, possible-fit, and next-step language.</p>
     </section>
   </main>
+
   <footer class="footer">
     <p><strong>AI Agent Library</strong> — reusable agents, skills, prompt systems, knowledge bases, platform packs, and deployable AI product assets.</p>
     <p>

--- a/script.js
+++ b/script.js
@@ -10,12 +10,16 @@ window.AILibrary = (() => {
 
   async function fetchJSON(paths, fallback = []) {
     const list = Array.isArray(paths) ? paths : [paths];
+
     for (const path of list) {
       try {
         const response = await fetch(path, { cache: "no-store" });
         if (response.ok) return await response.json();
-      } catch (error) {}
+      } catch (error) {
+        // Static-first fallback. Missing optional JSON should not kill the page.
+      }
     }
+
     return fallback;
   }
 
@@ -23,34 +27,94 @@ window.AILibrary = (() => {
     return [...new Set((values || []).filter(Boolean))].sort((a, b) => String(a).localeCompare(String(b)));
   }
 
+  function slugify(text) {
+    return String(text || "")
+      .toLowerCase()
+      .trim()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/(^-|-$)/g, "");
+  }
+
+  function queryParam(name, fallback = "") {
+    const params = new URLSearchParams(window.location.search);
+    return params.get(name) || fallback;
+  }
+
+  function normalizePriority(value) {
+    const raw = String(value || "Medium").toLowerCase();
+    if (raw === "high") return "High";
+    if (raw === "low") return "Low";
+    return "Medium";
+  }
+
+  function normalizeStatus(value) {
+    const raw = String(value || "Draft").toLowerCase();
+    if (raw === "ready") return "Ready";
+    if (raw === "planned") return "Planned";
+    if (raw === "needs review" || raw === "needs-review") return "Needs Review";
+    if (raw === "published") return "Published";
+    return raw ? raw.charAt(0).toUpperCase() + raw.slice(1) : "Draft";
+  }
+
   function normalizeAgent(agent, index = 0) {
+    const name = agent.name || `Agent ${index + 1}`;
+    const slug = agent.slug || slugify(name) || `agent-${index + 1}`;
+
     return {
-      name: agent.name || `Agent ${index + 1}`,
-      slug: agent.slug || `agent-${index + 1}`,
+      number: agent.number || index + 1,
+      name,
+      slug,
       category: agent.category || "Uncategorized",
       buyer: agent.buyer || agent.audience || "Builder / operator",
       pain_solved: agent.pain_solved || agent.problem_solved || agent.description || "Reusable AI agent pattern.",
       monetization: agent.monetization || "TBD",
       platform: agent.platform || "Platform TBD",
-      status: agent.status || "Draft",
-      priority: agent.priority || "Medium",
+      status: normalizeStatus(agent.status || "Draft"),
+      priority: normalizePriority(agent.priority || "Medium"),
       tags: agent.tags || [],
       file: agent.file || ""
     };
   }
 
   function normalizeSkill(skill, index = 0) {
+    const name = skill.name || `Skill ${index + 1}`;
+    const slug = skill.slug || slugify(name) || `skill-${index + 1}`;
+
     return {
-      name: skill.name || `Skill ${index + 1}`,
-      slug: skill.slug || `skill-${index + 1}`,
+      name,
+      slug,
       category: skill.category || "Uncategorized",
       audience: skill.audience || "Builder / operator",
       problem_solved: skill.problem_solved || skill.description || "Reusable skill pattern.",
       recommended_apps: skill.recommended_apps || skill.apps || [],
-      priority: skill.priority || "Medium",
-      status: skill.status || "Draft",
-      path: skill.path || skill.file || ""
+      priority: normalizePriority(skill.priority || "Medium"),
+      status: normalizeStatus(skill.status || "Draft"),
+      path: skill.path || skill.file || `skills/${slug}/SKILL.md`,
+      related_agents: skill.related_agents || [],
+      related_knowledge_bases: skill.related_knowledge_bases || []
     };
+  }
+
+  function priorityWeight(priority) {
+    return { High: 1, Medium: 2, Low: 3 }[normalizePriority(priority)] || 99;
+  }
+
+  function listLines(items, fallback = "- TBD") {
+    const list = (items || []).filter(Boolean);
+    if (!list.length) return fallback;
+    return list.map((item) => `- ${item}`).join("\n");
+  }
+
+  async function copyText(text, button) {
+    await navigator.clipboard.writeText(text);
+
+    if (button) {
+      const original = button.textContent;
+      button.textContent = "Copied";
+      setTimeout(() => {
+        button.textContent = original;
+      }, 1200);
+    }
   }
 
   function setYear() {
@@ -61,5 +125,19 @@ window.AILibrary = (() => {
 
   document.addEventListener("DOMContentLoaded", setYear);
 
-  return { escapeHTML, fetchJSON, unique, normalizeAgent, normalizeSkill, setYear };
+  return {
+    escapeHTML,
+    fetchJSON,
+    unique,
+    slugify,
+    queryParam,
+    normalizePriority,
+    normalizeStatus,
+    normalizeAgent,
+    normalizeSkill,
+    priorityWeight,
+    listLines,
+    copyText,
+    setYear
+  };
 })();

--- a/skill-builder.html
+++ b/skill-builder.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <title>Skill Builder | AI Agent Library</title>
-  <meta name="description" content="Generate a reusable SKILL.md file for agent capabilities, static pages, platform packs, and workflow systems.">
+  <meta name="description" content="Generate a reusable SKILL.md file from a catalog skill or a custom capability draft.">
 
   <link rel="stylesheet" href="styles.css">
 </head>
@@ -23,7 +23,7 @@
       <nav class="nav-links" aria-label="Primary navigation">
         <a href="index.html">Home</a>
         <a href="agent-catalog.html">Agents</a>
-        <a href="skill-catalog.html">Skills</a>
+        <a href="skill-catalog.html" aria-current="page">Skills</a>
         <a href="categories.html">Categories</a>
         <a href="platforms.html">Platforms</a>
         <a href="knowledge-bases.html">Knowledge</a>
@@ -38,8 +38,7 @@
     <div class="eyebrow">Skills Library</div>
     <h1>Skill Builder</h1>
     <p>
-      Generate a reusable SKILL.md file for agent capabilities, static pages,
-      platform packs, and workflow systems.
+      Open a catalog skill as a prefilled builder, edit the fields, then generate a reusable SKILL.md package draft.
     </p>
   </section>
 
@@ -47,11 +46,17 @@
     <section class="section card">
       <h2>Skill generator</h2>
       <p>
-        Use this lightweight builder to draft a reusable skill file that can be added
-        under <code>skills/[skill-slug]/SKILL.md</code>.
+        This builder now loads catalog skills from <code>skills/skill-index.json</code>. Use the dropdown or pass <code>?skill=skill-slug</code> in the URL.
       </p>
 
       <div class="form-grid">
+        <label>
+          Catalog skill
+          <select id="skillSelect">
+            <option value="custom">Custom / blank skill</option>
+          </select>
+        </label>
+
         <label>
           Skill name
           <input id="skillName" placeholder="Partner Resource Card Builder">
@@ -93,6 +98,7 @@
             <option>Planned</option>
             <option>Ready</option>
             <option>Needs Review</option>
+            <option>Published</option>
           </select>
         </label>
 
@@ -104,12 +110,13 @@
 
       <label style="margin-top: 1rem;">
         Implementation notes
-        <textarea id="skillNotes" placeholder="Inputs, outputs, guardrails, examples, and implementation notes..."></textarea>
+        <textarea id="skillNotes" placeholder="Inputs, outputs, guardrails, examples, implementation notes, related agents, and related knowledge bases..."></textarea>
       </label>
 
       <div class="pill-row">
         <button class="button" id="buildSkill">Generate SKILL.md</button>
         <button class="button secondary" id="copySkill">Copy generated markdown</button>
+        <a class="button-link secondary" href="skill-catalog.html">Back to catalog →</a>
       </div>
     </section>
 
@@ -121,13 +128,11 @@
       <article class="card">
         <h2>Skill file requirements</h2>
         <ul class="mini-list">
-          <li>Use a clear capability name.</li>
-          <li>Define the audience and problem solved.</li>
-          <li>Specify required inputs.</li>
-          <li>Specify standard outputs.</li>
-          <li>Include implementation notes.</li>
-          <li>Include guardrails.</li>
-          <li>Include a suggested repo path.</li>
+          <li>Clear capability name.</li>
+          <li>Defined audience and problem solved.</li>
+          <li>Required inputs and standard outputs.</li>
+          <li>Workflow steps that can be reused.</li>
+          <li>Guardrails, examples, and suggested repo path.</li>
         </ul>
       </article>
 
@@ -164,34 +169,78 @@
   <script src="script.js"></script>
 
   <script>
-    const output = document.getElementById("skillOutput");
-    const buildButton = document.getElementById("buildSkill");
-    const copyButton = document.getElementById("copySkill");
+    (async () => {
+      const output = document.getElementById("skillOutput");
+      const buildButton = document.getElementById("buildSkill");
+      const copyButton = document.getElementById("copySkill");
+      const skillSelect = document.getElementById("skillSelect");
+      const rawSkills = await AILibrary.fetchJSON(["skills/skill-index.json", "site-data/skills.fallback.json"], []);
+      const skills = rawSkills.map(AILibrary.normalizeSkill);
 
-    function value(id) {
-      return document.getElementById(id).value.trim();
-    }
+      const fields = {
+        name: document.getElementById("skillName"),
+        category: document.getElementById("skillCat"),
+        audience: document.getElementById("skillAudience"),
+        problem: document.getElementById("skillProblem"),
+        apps: document.getElementById("skillApps"),
+        priority: document.getElementById("skillPriority"),
+        status: document.getElementById("skillStatus"),
+        path: document.getElementById("skillPath"),
+        notes: document.getElementById("skillNotes")
+      };
 
-    function slugify(text) {
-      return text
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, "-")
-        .replace(/(^-|-$)/g, "");
-    }
+      function value(id) {
+        return document.getElementById(id).value.trim();
+      }
 
-    function buildMarkdown() {
-      const name = value("skillName") || "Untitled Skill";
-      const category = value("skillCat") || "Uncategorized";
-      const audience = value("skillAudience") || "Unknown";
-      const problem = value("skillProblem") || "Unknown";
-      const apps = value("skillApps") || "ChatGPT";
-      const priority = value("skillPriority") || "Medium";
-      const status = value("skillStatus") || "Draft";
-      const notes = value("skillNotes") || "Add implementation details here.";
-      const slug = slugify(name) || "untitled-skill";
-      const suggestedPath = value("skillPath") || `skills/${slug}/SKILL.md`;
+      function selectedSkill() {
+        return skills.find((skill) => skill.slug === skillSelect.value);
+      }
 
-      return `# ${name}
+      function setSelectValue(select, desired) {
+        const normalized = String(desired || "").toLowerCase();
+        const option = [...select.options].find((item) => item.value.toLowerCase() === normalized || item.textContent.toLowerCase() === normalized);
+        if (option) select.value = option.value;
+      }
+
+      function fillFromSkill(skill) {
+        if (!skill) return;
+
+        fields.name.value = skill.name;
+        fields.category.value = skill.category;
+        fields.audience.value = skill.audience;
+        fields.problem.value = skill.problem_solved;
+        fields.apps.value = (skill.recommended_apps || []).join(", ");
+        setSelectValue(fields.priority, skill.priority);
+        setSelectValue(fields.status, skill.status);
+        fields.path.value = skill.path;
+        fields.notes.value = [
+          "Related agents:",
+          AILibrary.listLines(skill.related_agents, "- TBD"),
+          "",
+          "Related knowledge bases:",
+          AILibrary.listLines(skill.related_knowledge_bases, "- TBD"),
+          "",
+          "Implementation notes:",
+          "Use this skill as a reusable capability package. Add examples, input schema, output schema, and tests before marking it ready."
+        ].join("\n");
+
+        buildMarkdown();
+      }
+
+      function buildMarkdown() {
+        const name = value("skillName") || "Untitled Skill";
+        const category = value("skillCat") || "Uncategorized";
+        const audience = value("skillAudience") || "Unknown";
+        const problem = value("skillProblem") || "Unknown";
+        const apps = value("skillApps") || "ChatGPT";
+        const priority = value("skillPriority") || "Medium";
+        const status = value("skillStatus") || "Draft";
+        const notes = value("skillNotes") || "Add implementation details here.";
+        const slug = AILibrary.slugify(name) || "untitled-skill";
+        const suggestedPath = value("skillPath") || `skills/${slug}/SKILL.md`;
+
+        const markdown = `# ${name}
 
 ## Category
 
@@ -284,26 +333,39 @@ Constraints:
 
 \`${suggestedPath}\`
 `;
-    }
 
-    buildButton.addEventListener("click", () => {
-      output.textContent = buildMarkdown();
-    });
-
-    copyButton.addEventListener("click", async () => {
-      const text = output.textContent;
-
-      if (!text || text === "Generated skill file appears here.") {
-        output.textContent = buildMarkdown();
+        output.textContent = markdown;
+        return markdown;
       }
 
-      await navigator.clipboard.writeText(output.textContent);
-      copyButton.textContent = "Copied";
+      skills.forEach((skill) => {
+        skillSelect.insertAdjacentHTML("beforeend", `<option value="${AILibrary.escapeHTML(skill.slug)}">${AILibrary.escapeHTML(skill.name)}</option>`);
+      });
 
-      setTimeout(() => {
-        copyButton.textContent = "Copy generated markdown";
-      }, 1200);
-    });
+      const requestedSkill = AILibrary.queryParam("skill");
+      if (requestedSkill && skills.some((skill) => skill.slug === requestedSkill)) {
+        skillSelect.value = requestedSkill;
+        fillFromSkill(selectedSkill());
+      }
+
+      skillSelect.addEventListener("change", () => {
+        if (skillSelect.value === "custom") {
+          Object.values(fields).forEach((field) => {
+            if (field.tagName === "INPUT" || field.tagName === "TEXTAREA") field.value = "";
+          });
+          output.textContent = "Generated skill file appears here.";
+          return;
+        }
+
+        fillFromSkill(selectedSkill());
+      });
+
+      buildButton.addEventListener("click", buildMarkdown);
+      copyButton.addEventListener("click", async () => {
+        const text = output.textContent === "Generated skill file appears here." ? buildMarkdown() : output.textContent;
+        await AILibrary.copyText(text, copyButton);
+      });
+    })();
   </script>
 </body>
 </html>

--- a/skill-catalog.html
+++ b/skill-catalog.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <title>Skill Catalog | AI Agent Library</title>
-  <meta name="description" content="Browse reusable agent skills by category, audience, recommended platform, status, and implementation priority.">
+  <meta name="description" content="Browse reusable agent skills and open each one in a prefilled SKILL.md builder.">
 
   <link rel="stylesheet" href="styles.css">
 </head>
@@ -38,15 +38,19 @@
     <div class="eyebrow">Skills Library</div>
     <h1>Skill Catalog</h1>
     <p>
-      Browse reusable agent skills by category, audience, recommended platform,
-      status, and implementation priority.
+      Browse reusable capabilities, then open any skill in a prefilled builder to generate a usable SKILL.md file and supporting implementation notes.
     </p>
   </section>
 
   <main id="main">
+    <section class="section callout">
+      <strong>Skill catalog rule:</strong>
+      <p>Skills are not just cards. A skill should become a reusable capability package with inputs, outputs, workflow, guardrails, examples, and a repo path.</p>
+    </section>
+
     <section class="section">
       <div class="toolbar">
-        <input id="skillSearch" type="search" placeholder="Search skills...">
+        <input id="skillSearch" type="search" placeholder="Search skills, platforms, audiences...">
 
         <select id="skillCategory">
           <option value="all">All categories</option>
@@ -70,23 +74,22 @@
 
     <section class="section two-col">
       <article class="card">
-        <h2>What counts as a skill?</h2>
+        <h2>What counts as a useful skill?</h2>
         <p>
-          A skill is a reusable capability that can power multiple agents, pages,
-          workflows, platform packs, or internal operating systems.
+          A skill is a repeatable capability that an agent, workflow, site, Custom GPT, Notion system, or automation can reuse.
         </p>
 
         <ul class="mini-list">
-          <li>It should have a narrow job.</li>
-          <li>It should define required inputs.</li>
-          <li>It should produce a structured output.</li>
-          <li>It should include guardrails.</li>
-          <li>It should be reusable across more than one asset.</li>
+          <li>It has a narrow job.</li>
+          <li>It defines required inputs.</li>
+          <li>It generates standard outputs.</li>
+          <li>It includes examples and guardrails.</li>
+          <li>It can be reused across more than one asset.</li>
         </ul>
       </article>
 
       <article class="card">
-        <h2>Recommended skill file format</h2>
+        <h2>Recommended skill package</h2>
         <pre>skills/
   [skill-slug]/
     SKILL.md
@@ -141,16 +144,6 @@
         );
       });
 
-      function priorityWeight(priority) {
-        const weights = {
-          High: 1,
-          Medium: 2,
-          Low: 3
-        };
-
-        return weights[priority] || 99;
-      }
-
       function renderSkills() {
         const query = searchInput.value.toLowerCase();
         const category = categorySelect.value;
@@ -164,6 +157,7 @@
             skill.problem_solved,
             skill.status,
             skill.priority,
+            skill.path,
             (skill.recommended_apps || []).join(" ")
           ].join(" ").toLowerCase();
 
@@ -183,7 +177,7 @@
 
         if (sort === "priority") {
           filtered = filtered.sort((a, b) => {
-            return priorityWeight(a.priority) - priorityWeight(b.priority);
+            return AILibrary.priorityWeight(a.priority) - AILibrary.priorityWeight(b.priority);
           });
         }
 
@@ -205,6 +199,8 @@
         `;
 
         grid.innerHTML = filtered.map((skill) => {
+          const builderUrl = `skill-builder.html?skill=${encodeURIComponent(skill.slug)}`;
+
           return `
             <article class="card">
               <div class="pill-row">
@@ -229,9 +225,16 @@
                 }).join("") || `<span class="pill">Platform TBD</span>`}
               </div>
 
-              <a class="button-link secondary" href="skill-builder.html">
-                Build from this pattern →
-              </a>
+              <p><strong>Suggested path:</strong> <code>${AILibrary.escapeHTML(skill.path)}</code></p>
+
+              <div class="pill-row">
+                <a class="button-link" href="${builderUrl}">
+                  Open prefilled builder →
+                </a>
+                <a class="button-link secondary" href="${AILibrary.escapeHTML(skill.path)}">
+                  Open SKILL.md →
+                </a>
+              </div>
             </article>
           `;
         }).join("") || `<div class="empty-state">No matching skills.</div>`;


### PR DESCRIPTION
## Summary

This PR moves the static site from a display-only catalog toward an actual build console.

### Adds
- `agent-workbench.html`
  - Pick an agent from `agent-index.json`
  - Generate copy-ready assets for:
    - Custom GPT
    - Gemini Gem
    - Notion operating page
    - Static Vercel page
    - GitHub implementation issue
  - Shows buyer, pain solved, monetization, source file, and related skill matches

### Changes
- `index.html`
  - Repositions the homepage around utility instead of passive browsing
  - Adds primary CTA to Agent Workbench
- `agent-catalog.html`
  - Makes catalog cards open the Agent Workbench first
  - Keeps raw Markdown source file links as secondary actions
- `skill-catalog.html`
  - Makes skill cards open a prefilled Skill Builder
  - Adds direct SKILL.md links as secondary actions
- `skill-builder.html`
  - Loads `skills/skill-index.json`
  - Supports `?skill=skill-slug`
  - Prefills fields from catalog records
  - Generates a usable SKILL.md draft
- `script.js`
  - Adds shared helpers for slugging, query params, normalization, copy behavior, and reusable list output

## Why

The prior site looked like a catalog but acted like a hallway of fake doors. Agent cards opened raw Markdown files, skill cards all opened the same blank builder, and several pages had no real operator utility.

This PR creates the first working utility layer: choose an agent or skill and generate something useful.

## Scope discipline

- Static HTML/CSS/JS only
- No framework or build step
- No API calls
- No private data or secrets
- No backend provider exposure
- Source Markdown links remain available but no longer function as the primary user action

## Manual test checklist

- Open `/`
- Click `Open Agent Workbench`
- Select multiple agents and generate each output type
- Open `/agent-catalog.html`
- Confirm cards route to `/agent-workbench.html?agent=...`
- Open `/skill-catalog.html`
- Confirm skill cards route to `/skill-builder.html?skill=...`
- Confirm Skill Builder fields prefill and generate copyable Markdown
