### PR TITLE
Add Moonshine CRM skill platform

### DIFF
--- a/docs/moonshine-skill-platform.md
+++ b/docs/moonshine-skill-platform.md
@@ -1,0 +1,22 @@
+# Moonshine Skill Platform
+
+## Ownership
+
+`JFeimster/ai-agent-library` is the canonical Git source for reusable Moonshine skill implementations. `JFeimster/ResourceGrid` stores discovery metadata, stable IDs, and relationships only. `JFeimster/ai-agent-arsenal` may surface external catalog entries or platform guidance, but never carries a forked implementation. Codex and ChatGPT installations are deployment targets, not editable sources.
+
+## Family
+
+The current operator family is intentionally modular:
+
+1. `moonshine-crm-intake`
+2. `moonshine-crm-note-normalizer`
+3. `moonshine-crm-schema-steward`
+4. `moonshine-crm-data-hygiene`
+5. `moonshine-funding-pipeline-health`
+6. `moonshine-funding-follow-up`
+7. `moonshine-crm-reconciler`
+
+## Change rule
+
+Update a skill here first, validate its Markdown, JSON/YAML metadata, paths, and public-safety boundaries, then update the ResourceGrid record. Deploy or sync only from this canonical source. Use synthetic examples and keep applicant, borrower, banking, credit, credential, and private provider data out of Git.
+

--- a/skills/moonshine-crm-data-hygiene/SKILL.md
+++ b/skills/moonshine-crm-data-hygiene/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: moonshine-crm-data-hygiene
+description: Audit and safely improve Moonshine Capital CRM record quality, duplicates, associations, stale work, and reconciliation backlog. Use for audits and cleanup planning, not routine intake.
+metadata:
+  version: 1.0.0
+---
+
+# Moonshine CRM Data Hygiene
+
+Audit contacts, companies, deals, associations, notes, tasks, malformed values, and conflicting source data. Classify each finding as a safe repair, review-required recommendation, or verified clean record.
+
+## Procedure
+
+1. Define coverage as complete, sampled, or partial/paginated.
+2. Detect duplicate candidates with evidence, not name similarity alone.
+3. Identify orphan associations, speculative companies, stale deals, missing notes, overdue tasks, incomplete records, and conflicting fields.
+4. Make only non-destructive, evidence-backed repairs when authorized; queue merges, deletes, and uncertain changes for review.
+5. Publish a prioritized cleanup backlog with record IDs, evidence, proposed action, owner, and risk.
+
+## Guardrails
+
+- Never merge or delete solely from fuzzy similarity.
+- Preserve source attribution and meaningful timeline history.
+- Dry-run canonical or destructive changes before applying them.
+

--- a/skills/moonshine-crm-data-hygiene/agents/openai.yaml
+++ b/skills/moonshine-crm-data-hygiene/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Moonshine CRM Data Hygiene"
+  short_description: "Audit CRM quality without reckless cleanup."
+  default_prompt: "Use $moonshine-crm-data-hygiene to produce a safe CRM cleanup backlog."
+policy:
+  allow_implicit_invocation: true
+

--- a/skills/moonshine-crm-intake/SKILL.md
+++ b/skills/moonshine-crm-intake/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: moonshine-crm-intake
+description: Process Moonshine Capital funding, affiliate, or partner intake from Gmail into HubSpot, Notion, and the Master CRM Sheet with evidence-backed enrichment, reconciliation, and follow-up. Use for Moonshine operations, not generic CRM work or standalone copywriting.
+metadata:
+  version: 2.1.0
+---
+
+# Moonshine CRM Intake
+
+Classify new Gmail items as funding applicant, affiliate or partner, existing-record update, or irrelevant. Preserve submitted facts exactly and label every added fact as `supplied`, `existing source`, `publicly sourced`, `inferred`, or `unverified research clue`.
+
+## Workflow
+
+1. Scan relevant inbox and sent-thread activity first; capture source, thread, timestamps, and intent.
+2. Before any write, inspect live HubSpot schema and search HubSpot, Notion, and the Master CRM Sheet for identity matches.
+3. Create or update contacts, companies, notes, and tasks when identity and intent are clear. Create deals only for qualified commercial opportunities; create tickets only for support or implementation work.
+4. Write the normalized internal note using [the note template](templates/normalized-note.md). Keep material funding claims, ambiguous routing, provider terms, and applicant decisions for human review.
+5. When a sent email or reply changes state, preserve the Gmail thread ID and update last touch, fulfilled task, current status, and the next follow-up.
+6. Report writes, evidence, missing information, exceptions, and one recommended next action per active record.
+
+## Required controls
+
+- Do a live-schema preflight before using uncertain properties, pipeline IDs, stages, lifecycle values, lead statuses, owners, or enum values. Prefer an existing standard property; use a note when no clean field exists.
+- State coverage as `complete`, `sampled`, or `partial/paginated`. Never call a limited search a complete audit.
+- Apply duplicate evidence in this order: exact email; exact phone; company domain or website; same name plus company; then supporting social/context clues. Never merge on a fuzzy name alone.
+- Automate administration, assist analysis, human-review the money talk, and leave an audit trail.
+
+Read [the operating contract](references/operating-contract.md) for the evidence, risk, and pipeline rules that govern this skill.
+
+## Guardrails
+
+- Never fabricate profiles, financial performance, approval status, commitments, lender terms, or outreach.
+- Never commit or expose private applicant data, bank data, credit files, credentials, or secrets.
+- Draft recurring outreach as a reply in the original Gmail thread when one exists.
+

--- a/skills/moonshine-crm-intake/agents/openai.yaml
+++ b/skills/moonshine-crm-intake/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Moonshine CRM Intake"
+  short_description: "Process Moonshine funding and partner intake safely."
+  default_prompt: "Use $moonshine-crm-intake to reconcile this Moonshine Capital intake into the CRM."
+policy:
+  allow_implicit_invocation: true
+

--- a/skills/moonshine-crm-intake/references/operating-contract.md
+++ b/skills/moonshine-crm-intake/references/operating-contract.md
@@ -1,0 +1,18 @@
+# Moonshine CRM Intake Operating Contract
+
+## Live schema and identity
+
+Inspect the live HubSpot object schema before property writes. Record an uncertain fact in the note rather than inventing a field or option. Resolve duplicates conservatively: exact email is very strong; exact phone, domain, or website is strong; same name and company is medium; a similar name or company is weak and requires corroboration.
+
+## Normalized note and source quality
+
+Use the seven-section note template. Keep source-quality labels beside facts that are not directly submitted. An inferred business relationship or public search clue is not a verified applicant fact.
+
+## Pipeline-risk signals
+
+Flag stale activity, overdue follow-up, no next action, expected deal amount missing, missing contact or questionable company association, application with no bank-link reminder, bank link with no underwriting update, repeated no-response, provider delay without a parallel-lane review, and stage conflict with recent Gmail activity.
+
+## Review boundary
+
+Routine non-destructive record maintenance may be automated when identity and intent are clear. A human reviews material financial representations, approval or eligibility claims, provider terms, ambiguous routing, and sensitive applicant decisions.
+

--- a/skills/moonshine-crm-intake/templates/normalized-note.md
+++ b/skills/moonshine-crm-intake/templates/normalized-note.md
@@ -1,0 +1,30 @@
+# Record Snapshot
+
+- Source:
+- Contact / company:
+- Funding or partnership intent:
+
+# Known Facts
+
+- Fact — source quality
+
+# Missing Information
+
+- Item needed and why
+
+# Caution Flags
+
+- Risk, ambiguity, or verification need
+
+# Timeline / Last Touch
+
+- Date — event — source/thread
+
+# Current Status
+
+- Current operating queue and evidence
+
+# Next Action
+
+- Owner, due timing, and expected outcome
+

--- a/skills/moonshine-crm-note-normalizer/SKILL.md
+++ b/skills/moonshine-crm-note-normalizer/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: moonshine-crm-note-normalizer
+description: Normalize Moonshine Capital form submissions, Gmail threads, calls, SMS, screenshots, CRM notes, and web research into an evidence-labeled internal CRM note. Use before CRM writes when source material is messy.
+metadata:
+  version: 1.0.0
+---
+
+# Moonshine CRM Note Normalizer
+
+Transform messy operational inputs into a consistent internal note without upgrading inference into fact.
+
+## Procedure
+
+1. Extract only supported facts and label source quality: supplied, existing source, publicly sourced, inferred, or unverified research clue.
+2. Separate facts, missing information, risks, timeline, current status, and next action.
+3. Preserve source links, dates, and Gmail-thread context when supplied.
+4. Suggest one task and the minimum follow-up inputs needed; do not claim funding status or invent financial data.
+
+Use [the canonical note layout](templates/normalized-note.md). Use the intake skill for cross-system writes and duplicate resolution.
+

--- a/skills/moonshine-crm-note-normalizer/agents/openai.yaml
+++ b/skills/moonshine-crm-note-normalizer/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Moonshine CRM Note Normalizer"
+  short_description: "Turn messy intake evidence into clean CRM notes."
+  default_prompt: "Use $moonshine-crm-note-normalizer to normalize these Moonshine CRM sources."
+policy:
+  allow_implicit_invocation: true
+

--- a/skills/moonshine-crm-note-normalizer/templates/normalized-note.md
+++ b/skills/moonshine-crm-note-normalizer/templates/normalized-note.md
@@ -1,0 +1,34 @@
+# Record Snapshot
+
+- Source and timestamp:
+- Person / company:
+- Intent:
+
+# Known Facts
+
+- Fact — source quality
+
+# Missing Information
+
+- Information needed
+
+# Caution Flags
+
+- Ambiguity, conflict, or review boundary
+
+# Timeline
+
+- Date — event — source
+
+# Current Status
+
+- Evidence-backed operating state
+
+# Internal CRM Note
+
+- Concise narrative for the record
+
+# Next Action / Suggested Task
+
+- Owner, timing, action, and required follow-up inputs
+

--- a/skills/moonshine-crm-reconciler/SKILL.md
+++ b/skills/moonshine-crm-reconciler/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: moonshine-crm-reconciler
+description: Reconcile Moonshine Capital operational state across Gmail, HubSpot, Notion, and the Master CRM Sheet. Use only when cross-system drift or conflicts need investigation.
+metadata:
+  version: 1.0.0
+---
+
+# Moonshine CRM Reconciler
+
+Investigate cross-system identity, status, task, and communication mismatches. This is not the default intake path; activate it when a record or batch has meaningful system drift.
+
+## Procedure
+
+1. Declare the systems, date range, and coverage level being reconciled.
+2. Resolve identity with the intake evidence hierarchy; retain unresolved candidates rather than merging them.
+3. Compare record presence, key facts, stages/status, associations, tasks, notes, and recent communications.
+4. Identify the canonical correction using source reliability and recency; propose safe deterministic repairs separately from review-required changes.
+5. Output a reconciliation ledger with the conflict, evidence, recommended canonical state, proposed mutation, owner, and confidence.
+
+## Guardrails
+
+- Preserve the original source trail and never invent a canonical state.
+- Do not make destructive corrections without a dry run and explicit authorization.
+- Keep private CRM, Gmail, bank, and applicant data out of public artifacts.
+

--- a/skills/moonshine-crm-reconciler/agents/openai.yaml
+++ b/skills/moonshine-crm-reconciler/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Moonshine CRM Reconciler"
+  short_description: "Resolve cross-system CRM drift with evidence."
+  default_prompt: "Use $moonshine-crm-reconciler to investigate this Moonshine CRM mismatch."
+policy:
+  allow_implicit_invocation: true
+

--- a/skills/moonshine-crm-schema-steward/SKILL.md
+++ b/skills/moonshine-crm-schema-steward/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: moonshine-crm-schema-steward
+description: Govern Moonshine Capital's constrained HubSpot schema, field mapping, and custom-property budget. Use before recommending CRM fields, enum values, or schema changes.
+metadata:
+  version: 1.0.0
+---
+
+# Moonshine CRM Schema Steward
+
+Inspect the live Contact, Company, and Deal schemas before proposing changes. Inventory standard, integration-managed, and custom properties; protect the HubSpot Free custom-property budget; and maintain a canonical mapping from intake concepts to approved destinations.
+
+## Procedure
+
+1. Retrieve the live schema and valid enum values.
+2. Classify each field as standard, integration-managed, custom, duplicate, or note-only.
+3. Map the requested information to an existing supported destination first.
+4. Recommend a new property only when it is durable, repeatedly used, automatable, and materially improves reporting or routing.
+5. Produce a change proposal with field purpose, object, type, allowed values, existing alternatives, budget impact, and migration/rollback notes.
+
+## Guardrails
+
+- Never invent a property, value, pipeline, or stage.
+- Prefer notes for one-off, ambiguous, sensitive, or volatile information.
+- Do not mutate live schema without explicit authorization and a reviewable proposal.
+

--- a/skills/moonshine-crm-schema-steward/agents/openai.yaml
+++ b/skills/moonshine-crm-schema-steward/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Moonshine CRM Schema Steward"
+  short_description: "Protect HubSpot schema quality and field budget."
+  default_prompt: "Use $moonshine-crm-schema-steward to evaluate this proposed CRM field change."
+policy:
+  allow_implicit_invocation: true
+

--- a/skills/moonshine-funding-follow-up/SKILL.md
+++ b/skills/moonshine-funding-follow-up/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: moonshine-funding-follow-up
+description: Orchestrate evidence-based Moonshine Capital funding follow-up after intake, without duplicate outreach or unsupported funding claims. Use for active applications and reactivation.
+metadata:
+  version: 1.0.0
+---
+
+# Moonshine Funding Follow-up
+
+Coordinate next-day application follow-up, 48-hour no-response, bank-link reminders, missing-document requests, underwriting checks, parallel-lane review, final check-ins, nurture, reactivation, and renewals.
+
+## Procedure
+
+1. Search open tasks and the existing Gmail thread before proposing outreach.
+2. Identify the latest verified state and the specific missing action or document.
+3. Choose the lowest-friction next touch, preserving the existing thread where possible.
+4. Create or update exactly one appropriate task with owner, due date, purpose, and completion condition.
+5. Draft copy only from verified facts and state review boundaries for terms, eligibility, and timing.
+
+## Guardrails
+
+- Do not duplicate a recent touch or override a live owner/task without evidence.
+- Do not promise approval, rates, speed, or lender outcomes.
+- Route ambiguous status, sensitive decisions, and material money talk to a human.
+

--- a/skills/moonshine-funding-follow-up/agents/openai.yaml
+++ b/skills/moonshine-funding-follow-up/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Moonshine Funding Follow-up"
+  short_description: "Coordinate funding follow-up without duplicate churn."
+  default_prompt: "Use $moonshine-funding-follow-up to plan the next verified follow-up."
+policy:
+  allow_implicit_invocation: true
+

--- a/skills/moonshine-funding-pipeline-health/SKILL.md
+++ b/skills/moonshine-funding-pipeline-health/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: moonshine-funding-pipeline-health
+description: Turn Moonshine Capital's active funding opportunities into evidence-backed operating queues with recommended next actions. Use for active-pipeline reviews, not approval decisions.
+metadata:
+  version: 1.0.0
+---
+
+# Moonshine Funding Pipeline Health
+
+Classify active opportunities into operational queues: Active, Needs Jason, Needs Applicant, Needs Provider, Missing Docs, Bank Link Needed, Underwriting Pending, No Response, Overdue, Parallel Lane Candidate, Ready for Next Stage, and Nurture / Close Review.
+
+## Procedure
+
+1. Inspect live deal stages, tasks, associations, notes, and recent Gmail context.
+2. Mark data coverage clearly and detect stage conflicts rather than silently correcting them.
+3. Assign each deal one primary queue, evidence, urgency, next action, responsible owner, and due timing.
+4. Flag pipeline risks: stale activity, no next action, missing amount where expected, missing association, bank-link or underwriting gaps, provider delay, repeated silence, and mismatched communication state.
+5. Escalate financial representations, provider terms, and disposition decisions for human review.
+
+## Output
+
+Return a ranked operator queue; a risk summary; and a short list of deterministic fixes that can safely be automated.
+

--- a/skills/moonshine-funding-pipeline-health/agents/openai.yaml
+++ b/skills/moonshine-funding-pipeline-health/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Moonshine Funding Pipeline Health"
+  short_description: "Prioritize funding opportunities and next actions."
+  default_prompt: "Use $moonshine-funding-pipeline-health to review the active Moonshine funding pipeline."
+policy:
+  allow_implicit_invocation: true
+

--- a/skills/skill-index.json
+++ b/skills/skill-index.json
@@ -309,5 +309,152 @@
     "related_knowledge_bases": [
       "portfolio/vercel/README.md"
     ]
+  },
+  {
+    "name": "Moonshine CRM Intake",
+    "slug": "moonshine-crm-intake",
+    "category": "CRM Operations",
+    "audience": "Moonshine Capital funding and partner operators",
+    "problem_solved": "Processes Moonshine Capital funding and partner intake with evidence-backed cross-system CRM updates.",
+    "recommended_apps": [
+      "ChatGPT",
+      "Codex",
+      "HubSpot",
+      "Gmail",
+      "Notion",
+      "Google Sheets"
+    ],
+    "priority": "high",
+    "status": "active",
+    "version": "2.1.0",
+    "path": "skills/moonshine-crm-intake/SKILL.md",
+    "related_agents": [],
+    "related_knowledge_bases": []
+  },
+  {
+    "name": "Moonshine CRM Schema Steward",
+    "slug": "moonshine-crm-schema-steward",
+    "category": "CRM Operations",
+    "audience": "Moonshine Capital funding and partner operators",
+    "problem_solved": "Protects the constrained HubSpot schema and custom-property budget before CRM field changes.",
+    "recommended_apps": [
+      "ChatGPT",
+      "Codex",
+      "HubSpot",
+      "Gmail",
+      "Notion",
+      "Google Sheets"
+    ],
+    "priority": "high",
+    "status": "active",
+    "version": "1.0.0",
+    "path": "skills/moonshine-crm-schema-steward/SKILL.md",
+    "related_agents": [],
+    "related_knowledge_bases": []
+  },
+  {
+    "name": "Moonshine CRM Data Hygiene",
+    "slug": "moonshine-crm-data-hygiene",
+    "category": "CRM Operations",
+    "audience": "Moonshine Capital funding and partner operators",
+    "problem_solved": "Audits duplicates, associations, stale work, and data-quality risks without reckless cleanup.",
+    "recommended_apps": [
+      "ChatGPT",
+      "Codex",
+      "HubSpot",
+      "Gmail",
+      "Notion",
+      "Google Sheets"
+    ],
+    "priority": "high",
+    "status": "active",
+    "version": "1.0.0",
+    "path": "skills/moonshine-crm-data-hygiene/SKILL.md",
+    "related_agents": [],
+    "related_knowledge_bases": []
+  },
+  {
+    "name": "Moonshine Funding Pipeline Health",
+    "slug": "moonshine-funding-pipeline-health",
+    "category": "Funding Operations",
+    "audience": "Moonshine Capital funding and partner operators",
+    "problem_solved": "Turns active funding opportunities into evidence-backed operating queues and next actions.",
+    "recommended_apps": [
+      "ChatGPT",
+      "Codex",
+      "HubSpot",
+      "Gmail",
+      "Notion",
+      "Google Sheets"
+    ],
+    "priority": "high",
+    "status": "active",
+    "version": "1.0.0",
+    "path": "skills/moonshine-funding-pipeline-health/SKILL.md",
+    "related_agents": [],
+    "related_knowledge_bases": []
+  },
+  {
+    "name": "Moonshine CRM Note Normalizer",
+    "slug": "moonshine-crm-note-normalizer",
+    "category": "CRM Operations",
+    "audience": "Moonshine Capital funding and partner operators",
+    "problem_solved": "Normalizes intake and communications into evidence-labeled internal CRM notes.",
+    "recommended_apps": [
+      "ChatGPT",
+      "Codex",
+      "HubSpot",
+      "Gmail",
+      "Notion",
+      "Google Sheets"
+    ],
+    "priority": "high",
+    "status": "active",
+    "version": "1.0.0",
+    "path": "skills/moonshine-crm-note-normalizer/SKILL.md",
+    "related_agents": [],
+    "related_knowledge_bases": []
+  },
+  {
+    "name": "Moonshine Funding Follow-up",
+    "slug": "moonshine-funding-follow-up",
+    "category": "Funding Operations",
+    "audience": "Moonshine Capital funding and partner operators",
+    "problem_solved": "Coordinates verified application and reactivation follow-up without duplicate outreach.",
+    "recommended_apps": [
+      "ChatGPT",
+      "Codex",
+      "HubSpot",
+      "Gmail",
+      "Notion",
+      "Google Sheets"
+    ],
+    "priority": "high",
+    "status": "active",
+    "version": "1.0.0",
+    "path": "skills/moonshine-funding-follow-up/SKILL.md",
+    "related_agents": [],
+    "related_knowledge_bases": []
+  },
+  {
+    "name": "Moonshine CRM Reconciler",
+    "slug": "moonshine-crm-reconciler",
+    "category": "CRM Operations",
+    "audience": "Moonshine Capital funding and partner operators",
+    "problem_solved": "Reconciles identity, status, task, and communication drift across Moonshine operating systems.",
+    "recommended_apps": [
+      "ChatGPT",
+      "Codex",
+      "HubSpot",
+      "Gmail",
+      "Notion",
+      "Google Sheets"
+    ],
+    "priority": "medium",
+    "status": "active",
+    "version": "1.0.0",
+    "path": "skills/moonshine-crm-reconciler/SKILL.md",
+    "related_agents": [],
+    "related_knowledge_bases": []
   }
 ]


### PR DESCRIPTION
# PR Summary

## Linked Issue or Batch

Moonshine Skill Platform Reconciliation + Buildout (user-authorized batch)

## What Changed

- Adds the canonical seven-skill Moonshine CRM and funding-operations family.
- Upgrades `moonshine-crm-intake` to v2.1 with live-schema, coverage, duplicate-evidence, normalized-note, automation, and pipeline-risk controls.
- Adds the skill index entries and source-of-truth documentation.

## Files Changed

```text
skills/moonshine-*/
skills/skill-index.json
docs/moonshine-skill-platform.md
```

## Validation

- [x] Skill package structure reviewed
- [x] JSON index parsed before commit
- [x] YAML metadata manually reviewed
- [x] No secrets or private applicant data
- [x] No unsupported funding claims

## Scope Control

- [x] Canonical skill source only
- [x] No deployment configuration changes
- [x] No unrelated refactors

## Known Issues

- Local `C:\\Users\\jason\\OneDrive\\Desktop\\JSON` workspace was not mounted in this execution environment; this PR is the canonical Git source for the new family.